### PR TITLE
[`models/cryptography`]: Trata erro de senha inválida no método `decryptData`

### DIFF
--- a/app/models/cryptography.ts
+++ b/app/models/cryptography.ts
@@ -50,11 +50,17 @@ function decryptData({
   privateKey,
   passphrase,
 }: DecryptDataProps) {
-  const bufferData = Buffer.from(encryptedData, 'base64');
-  const decryptedData = crypto.privateDecrypt(
-    { key: privateKey, passphrase },
-    bufferData,
-  );
+  try {
+    const bufferData = Buffer.from(encryptedData, 'base64');
+    const decryptedData = crypto.privateDecrypt(
+      { key: privateKey, passphrase },
+      bufferData,
+    );
 
-  return { decryptedData: JSON.parse(decryptedData.toString('utf8')) };
+    return { decryptedData: JSON.parse(decryptedData.toString('utf8')) };
+  } catch {
+    return {
+      error: 'Senha inválida para chave privada.',
+    };
+  }
 }

--- a/tests/models/cryptography.test.ts
+++ b/tests/models/cryptography.test.ts
@@ -51,4 +51,28 @@ describe('> models/cryptography', () => {
       decryptedData: data,
     });
   });
+
+  test('Invoking "decryptData" with wrong passphrase', () => {
+    const data = { name: 'Jane Doe', age: 25 };
+    const passphrase = 'password';
+
+    const { privateKey, publicKey } = cryptography.generateKeyPairs({
+      passphrase,
+    });
+
+    const { encryptedData } = cryptography.encryptData({
+      data,
+      publicKey,
+    });
+
+    const result = cryptography.decryptData({
+      encryptedData,
+      privateKey,
+      passphrase: 'wrong-password',
+    });
+
+    expect(result).toStrictEqual({
+      error: 'Senha inválida para chave privada.',
+    });
+  });
 });


### PR DESCRIPTION
- Na geração de chaves públicas e privadas (`generateKeyPairSync`), estou adicionando um `cipher` e uma `passphrase` nas opções de criação da chave privada. Portanto, essa `privateKey` gerada está criptografada.
- Para fazer a descriptografia de um valor que foi criptografado por uma chave pública correspondente, é preciso utilizar a chave privada "cru". Para isso, a fins de segurança, é necessário passar uma `passphrase` para descriptografar essa "chave privada" anteriormente.

### Fluxo de descriptografar uma mensagem que foi previamente criptografada com a chave pública correspondente:
1. chama o método `decryptData`
2. fornece o dado criptografado pela função `encryptData`
3. fornece a `privateKey` (está criptografada com a `passphrase`)
4. fornece a `passphrase` (utilizada para criptografar simetricamente a chave privada)