### PR TITLE
Implements `/pending-cards` admin page using `react-primer` table 

### DIFF
--- a/app/(pages)/(private)/(admin)/pending-cards/components/PendingTable.tsx
+++ b/app/(pages)/(private)/(admin)/pending-cards/components/PendingTable.tsx
@@ -1,0 +1,111 @@
+'use client';
+
+import { CheckIcon, XIcon } from '@primer/octicons-react';
+import { Avatar, Button } from '@primer/react';
+import { DataTable, Table } from '@primer/react/drafts';
+import { UserPendingData } from '@prisma/client';
+
+type PendingTableProps = {
+  pendingCards: UserPendingData[];
+};
+
+export function PendingTable({ pendingCards }: PendingTableProps) {
+  return (
+    <Table.Container>
+      <Table.Title as="h1" id="pending-cards">
+        Solicitações pendentes
+      </Table.Title>
+      <Table.Subtitle as="h3" id="pending-cards-subtitle">
+        Carteiras de estudante pendentes de emissão
+      </Table.Subtitle>
+      <DataTable
+        aria-labelledby="pending-cards"
+        aria-describedby="pending-cards-subtitle"
+        data={pendingCards}
+        columns={[
+          {
+            header: 'Foto',
+            field: 'photoUrl',
+            maxWidth: '80px',
+            renderCell: (row) => {
+              return <Avatar src={row.photoUrl} alt={`foto de ${row.name}`} />;
+            },
+          },
+          {
+            header: 'Email',
+            field: 'email',
+          },
+          {
+            header: 'CPF',
+            field: 'cpf',
+          },
+          {
+            header: 'CEP',
+            field: 'cep',
+          },
+          {
+            header: 'Endereço',
+            field: 'address',
+          },
+          {
+            header: 'Número',
+            field: 'number',
+          },
+          {
+            header: 'Complemento',
+            field: 'complement',
+            renderCell: (row) => {
+              return row.complement || 'Nenhum';
+            },
+          },
+          {
+            header: 'Curso',
+            field: 'course',
+          },
+          {
+            header: 'Data de solicitação',
+            field: 'createdAt',
+            renderCell: (row) => {
+              return new Date(row.createdAt).toLocaleDateString('pt-BR');
+            },
+            align: 'end',
+          },
+          {
+            header: 'Ações',
+            field: 'id',
+            renderCell: (row) => {
+              return (
+                <Table.Actions>
+                  <Button
+                    variant="primary"
+                    title="Aprovar solicitação"
+                    onClick={() => {
+                      // TODO: delete from UserPendingData where id = row.id
+                      console.log(
+                        `APROVAR:\n- ID: ${row.id}\n- UserID: ${row.userId}`,
+                      );
+                    }}
+                  >
+                    <CheckIcon />
+                  </Button>
+
+                  <Button
+                    variant="danger"
+                    title="Rejeitar solicitação"
+                    onClick={() => {
+                      console.log(
+                        `REJEITAR:\n- ID: ${row.id}\n- UserID: ${row.userId}`,
+                      );
+                    }}
+                  >
+                    <XIcon />
+                  </Button>
+                </Table.Actions>
+              );
+            },
+          },
+        ]}
+      />
+    </Table.Container>
+  );
+}

--- a/app/(pages)/(private)/(admin)/pending-cards/page.tsx
+++ b/app/(pages)/(private)/(admin)/pending-cards/page.tsx
@@ -1,5 +1,8 @@
+import { createUserRepository } from '@/repositories/userRepository';
 import { identity } from '@/utils/idendity';
+import { Box, Text } from '@primer/react';
 import { redirect, RedirectType } from 'next/navigation';
+import { PendingTable } from './components/PendingTable';
 
 export default async function Page() {
   const signedUser = await identity.isLoggedIn();
@@ -7,5 +10,24 @@ export default async function Page() {
     return redirect('/', RedirectType.replace);
   }
 
-  return <p>Solicitações de emissão de carteira pendentes</p>;
+  const userRepository = createUserRepository();
+  const pendingCards = await userRepository.findPendingUsers();
+
+  if (pendingCards.length === 0) {
+    return <Text>Nenhuma solicitação de emissão de carteira pendente</Text>;
+  }
+
+  return (
+    <Box
+      sx={{
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        overflowY: 'auto',
+      }}
+    >
+      <PendingTable pendingCards={pendingCards} />
+    </Box>
+  );
 }

--- a/app/(pages)/(private)/student-card/page.tsx
+++ b/app/(pages)/(private)/student-card/page.tsx
@@ -5,7 +5,9 @@ import { redirect, RedirectType } from 'next/navigation';
 
 export default async function Page() {
   const signedUser = await identity.isLoggedIn();
-  if (!signedUser) return redirect('/', RedirectType.replace);
+  if (!signedUser || signedUser.role === 'ADMIN') {
+    return redirect('/', RedirectType.replace);
+  }
 
   if (signedUser.status !== 'APPROVED') {
     return (

--- a/app/(pages)/(private)/student-card/status/page.tsx
+++ b/app/(pages)/(private)/student-card/status/page.tsx
@@ -4,7 +4,9 @@ import { redirect, RedirectType } from 'next/navigation';
 
 export default async function Page() {
   const signedUser = await identity.isLoggedIn();
-  if (!signedUser) return redirect('/', RedirectType.replace);
+  if (!signedUser || signedUser.role === 'ADMIN') {
+    return redirect('/', RedirectType.replace);
+  }
 
   let statusObject = {
     APPROVED: 'Aprovado',

--- a/app/components/NavListItem.tsx
+++ b/app/components/NavListItem.tsx
@@ -19,7 +19,7 @@ export function NavListItem({ item }: NavListItemProps) {
           width: 224,
         },
         '@media (min-width: 480px) and (max-width: 1919px)': {
-          width: 170,
+          width: 175,
         },
       }}
       as={Link}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -21,9 +21,15 @@ export default async function Home() {
         </Link>
       )}
 
-      {signedUser && (
+      {signedUser && signedUser.role === 'USER' && (
         <Link style={{ color: '#539bf5' }} href="/student-card">
           Ver carteira
+        </Link>
+      )}
+
+      {signedUser && signedUser.role === 'ADMIN' && (
+        <Link style={{ color: '#539bf5' }} href="/pending-cards">
+          Verificar carteiras pendentes
         </Link>
       )}
     </Box>

--- a/app/ui/Sidebar.tsx
+++ b/app/ui/Sidebar.tsx
@@ -30,8 +30,9 @@ export async function Sidebar() {
       >
         {navItems.map((item) => {
           if (!userSignedIn && item.auth.isPrivate) return null;
-          if (!isUserAdmin && item.auth.onlyAdmin) return null;
           if (userSignedIn && item.auth.onlyNotSignedIn) return null;
+          if (!isUserAdmin && item.auth.onlyAdmin) return null;
+          if (isUserAdmin && item.auth.onlyStudent) return null;
 
           return <NavListItem key={item.href} item={item} />;
         })}

--- a/repositories/userRepository.ts
+++ b/repositories/userRepository.ts
@@ -34,6 +34,7 @@ export function createUserRepository() {
     findByEmail,
     create,
     createPendingData,
+    findPendingUsers,
   });
   type WithPassword = {
     withPassword?: boolean;
@@ -114,6 +115,16 @@ export function createUserRepository() {
         email: true,
         userId: true,
         id: true,
+      },
+    });
+  }
+
+  async function findPendingUsers() {
+    return await prismaClient.userPendingData.findMany({
+      where: {
+        user: {
+          status: 'PENDING',
+        },
       },
     });
   }

--- a/tests/repositories/userRepository.test.ts
+++ b/tests/repositories/userRepository.test.ts
@@ -104,4 +104,50 @@ describe('> User Repository', () => {
       email: input.email,
     });
   });
+
+  it('should retrieve all pending users data', async () => {
+    await prismaClient.userPendingData.deleteMany();
+
+    const userRepository = createUserRepository();
+
+    const createdUser = await userRepository.create({
+      name: 'pending user test',
+      email: 'pending@mail.com',
+      passwordHash: randomUUID(),
+      publicKey: randomUUID(),
+    });
+
+    const input = {
+      name: createdUser.name,
+      email: createdUser.email,
+      cpf: '12345678901',
+      cep: '12345678',
+      address: 'Rua Teste',
+      number: '123',
+      complement: 'Casa',
+      course: 'Ciência da Computação',
+      photoUrl: 'http://test.com/photo.jpg',
+    };
+
+    await userRepository.createPendingData(createdUser.id, input);
+
+    const pendingUsers = await userRepository.findPendingUsers();
+
+    expect(pendingUsers).toStrictEqual([
+      {
+        id: expect.any(String),
+        userId: expect.any(String),
+        name: 'pending user test',
+        email: 'pending@mail.com',
+        cpf: '12345678901',
+        cep: '12345678',
+        address: 'Rua Teste',
+        number: '123',
+        complement: 'Casa',
+        course: 'Ciência da Computação',
+        photoUrl: 'http://test.com/photo.jpg',
+        createdAt: expect.any(Date),
+      },
+    ]);
+  });
 });

--- a/utils/navItems.tsx
+++ b/utils/navItems.tsx
@@ -16,6 +16,7 @@ export type NavItemProps = {
   auth: {
     isPrivate: boolean;
     onlyAdmin?: boolean;
+    onlyStudent?: boolean;
     onlyNotSignedIn?: boolean;
   };
 };
@@ -53,6 +54,7 @@ export const navItems: Array<NavItemProps> = [
     icon: <InfoIcon />,
     auth: {
       isPrivate: true,
+      onlyStudent: true,
     },
   },
   {
@@ -61,6 +63,7 @@ export const navItems: Array<NavItemProps> = [
     icon: <IdBadgeIcon />,
     auth: {
       isPrivate: true,
+      onlyStudent: true,
     },
   },
   {


### PR DESCRIPTION
## Done
- Implemented logic to make some pages accessible only to `NOT ADMIN` logged users.
- Created `findPendingUsers` functionality and tests for it;
- Created a custom table component, using [`primer`](https://primer.style/)
- Integrated admin page `/pending-cards` with `findPendingUsers` and custom table component     

## Preview
[Gravação de tela de 18-09-2024 21:54:12.webm](https://github.com/user-attachments/assets/22410feb-2d03-4134-bcca-07d50d4cb772)

