### PR TITLE
[`/issued-cards`]: Creates page to show all issued cards 

### DIFF
--- a/app/(pages)/(private)/(admin)/issued-cards/page.tsx
+++ b/app/(pages)/(private)/(admin)/issued-cards/page.tsx
@@ -1,0 +1,148 @@
+'use client';
+
+import { CopyToClipBoard } from '@/app/components/CopyToClipboard';
+import { useWeb3Context } from '@/app/contexts/Web3Context';
+import { Box, Label, Text } from '@primer/react';
+import { useEffect, useState } from 'react';
+import { EventLog } from 'web3';
+
+type IssuedCardEvent = {
+  blockHash: string;
+  transactionHash: string;
+  to: string;
+  cardIssued: {
+    expDate: number;
+    studentPublicKey: string;
+  };
+};
+
+export default function Page() {
+  const [issuedCards, setIssuedCards] = useState<Array<IssuedCardEvent>>([]);
+  const { web3Provider, contract } = useWeb3Context();
+
+  useEffect(() => {
+    getIssuedCards();
+
+    async function getIssuedCards() {
+      if (!web3Provider || !contract) return;
+
+      const events = (await contract.getPastEvents('CardIssued', {
+        fromBlock: 0,
+        toBlock: 'latest',
+      })) as EventLog[];
+
+      setIssuedCards(
+        events.map((event) => ({
+          blockHash: event.blockHash!,
+          transactionHash: event.transactionHash!,
+          to: event.address!,
+          cardIssued: {
+            expDate: Number(event.returnValues._expDate),
+            studentPublicKey: event.returnValues._studentPublicKey as string,
+          },
+        })),
+      );
+    }
+  }, [web3Provider, contract]);
+
+  if (!issuedCards.length) {
+    return (
+      <Text
+        sx={{
+          fontSize: 20,
+          color: 'slategray',
+        }}
+      >
+        Nenhuma carteira emitida!
+      </Text>
+    );
+  }
+
+  return (
+    <Box
+      sx={{
+        display: 'grid',
+        gridTemplateColumns: 'repeat(auto-fill, minmax(500px, 1fr))',
+        gap: 4,
+        placeItems: 'center',
+      }}
+    >
+      {issuedCards.map((card) => (
+        <Card card={card} key={card.cardIssued.studentPublicKey} />
+      ))}
+    </Box>
+  );
+}
+
+type CardProps = {
+  card: IssuedCardEvent;
+};
+
+function Card({ card }: CardProps) {
+  const [isCopied, setIsCopied] = useState(false);
+
+  const formattedDate = new Date(card.cardIssued.expDate).toLocaleDateString();
+
+  return (
+    <Box
+      sx={{
+        position: 'relative',
+        display: 'flex',
+        flexDirection: 'column',
+        width: '500px',
+        gap: 2,
+        backgroundColor: 'canvas.inset',
+        border: '1px solid',
+        borderRadius: 2,
+        padding: 2,
+        '@media (max-width: 620px)': {
+          fontSize: 10,
+        },
+        overflowX: 'auto',
+      }}
+    >
+      <span>
+        <Text sx={{ display: 'block' }}>Block Hash:</Text>
+        <Label sx={{ backgroundColor: 'canvas.overlay', p: 2 }}>
+          {card.blockHash}
+        </Label>
+      </span>
+
+      <span>
+        <Text sx={{ display: 'block' }}>Transaction Hash:</Text>
+        <Label sx={{ backgroundColor: 'canvas.overlay', p: 2 }}>
+          {card.transactionHash}
+        </Label>
+      </span>
+
+      <span>
+        <Text sx={{ display: 'block' }}>Expiration Date:</Text>
+        <Text
+          sx={{
+            color: 'slategray',
+          }}
+        >
+          {formattedDate}
+        </Text>
+      </span>
+
+      <span>
+        <Text sx={{ display: 'block' }}>Student public key:</Text>
+        <Label sx={{ backgroundColor: 'canvas.overlay', p: 2 }}>
+          {card.cardIssued.studentPublicKey}
+        </Label>
+      </span>
+
+      <CopyToClipBoard
+        sx={{
+          position: 'absolute',
+          bottom: 2,
+          right: 2,
+        }}
+        contentToCopy={JSON.stringify(card)}
+        isCopied={isCopied}
+        setIsCopied={setIsCopied}
+      />
+    </Box>
+  );
+}

--- a/app/(pages)/(private)/(admin)/pending-cards/components/PendingTable.tsx
+++ b/app/(pages)/(private)/(admin)/pending-cards/components/PendingTable.tsx
@@ -6,7 +6,6 @@ import { ActionList, ActionMenu, Avatar, Box, Text } from '@primer/react';
 import { DataTable, Table } from '@primer/react/drafts';
 import { UserPendingData } from '@prisma/client';
 import { useRouter } from 'next/navigation';
-import { useEffect } from 'react';
 import { encryptUserPendingDataAction } from '../action';
 
 type PendingTableProps = {
@@ -14,22 +13,7 @@ type PendingTableProps = {
 };
 
 export function PendingTable({ pendingCards }: PendingTableProps) {
-  const { web3Provider, account, provider, contract } = useWeb3Context();
-
-  useEffect(() => {
-    getIssuedCards();
-
-    async function getIssuedCards() {
-      if (!web3Provider || !contract) return;
-
-      const events = await contract.getPastEvents('CardIssued', {
-        fromBlock: 0,
-        toBlock: 'latest',
-      });
-
-      console.log({ events });
-    }
-  }, [web3Provider, contract]);
+  const { account, provider } = useWeb3Context();
 
   return (
     <>

--- a/app/components/CopyToClipboard.tsx
+++ b/app/components/CopyToClipboard.tsx
@@ -1,10 +1,10 @@
 'use client';
 
 import { CheckIcon, CopyIcon } from '@primer/octicons-react';
-import { Button } from '@primer/react';
+import { Button, ButtonProps } from '@primer/react';
 import { ReactNode } from 'react';
 
-type CopyToClipBoardProps = {
+type CopyToClipBoardProps = ButtonProps & {
   contentToCopy: string;
   setIsCopied: (value: boolean) => void;
   isCopied: boolean;
@@ -16,6 +16,7 @@ export function CopyToClipBoard({
   isCopied,
   setIsCopied,
   children,
+  ...props
 }: CopyToClipBoardProps) {
   function handleCopyToClipBoard() {
     navigator.clipboard.writeText(contentToCopy);
@@ -30,6 +31,7 @@ export function CopyToClipBoard({
       }}
       title="Copiar"
       onClick={handleCopyToClipBoard}
+      {...props}
     >
       {isCopied ? <CheckIcon /> : <CopyIcon />}
       {isCopied ? 'Copiado!' : children}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -26,6 +26,7 @@ export default function RootLayout({
         style={{
           height: '100%',
           width: '100%',
+          overflowY: 'hidden',
         }}
       >
         <StyledComponentsRegistry>

--- a/app/pageLayout.tsx
+++ b/app/pageLayout.tsx
@@ -36,6 +36,8 @@ export async function PageLayout({ children }: Props) {
             px: 4,
             py: 2,
             width: '100%',
+            height: '90vh',
+            overflowY: 'auto',
           }}
         >
           {userSigned && userSigned.role === 'ADMIN' ? (

--- a/utils/navItems.tsx
+++ b/utils/navItems.tsx
@@ -75,4 +75,13 @@ export const navItems: Array<NavItemProps> = [
       onlyAdmin: true,
     },
   },
+  {
+    title: 'Carteiras emitidas',
+    href: '/issued-cards',
+    icon: <ListUnorderedIcon />,
+    auth: {
+      isPrivate: true,
+      onlyAdmin: true,
+    },
+  },
 ];


### PR DESCRIPTION
## Context
- This PR implements `/issued-cards` page that is only available for `admins`. In this page, managers can see all the student cards emitted into the blockchain.
- All the cards issued are being caught by searching for the `CardIssued` smart-contract event, which is emitted when the smart-contract function `issueCard` runs.

## Preview
[Gravação de tela de 27-09-2024 21:46:24.webm](https://github.com/user-attachments/assets/b225dac7-d4a5-40ff-88e9-8e3980e99600)


## Next Steps
- Delete `user-pending-data` after `approve` a card and emit a transaction to the blockchain.
- Integrate smart-contract function `invalidateCard` with the project.
- Integrate smart-contract function `getCard` with the project.
- Check if the card caught is valid or not