### PR TITLE
Deletes `user-pending-data` after approve user and emit its data to blockchain

### DIFF
--- a/app/(pages)/(private)/(admin)/pending-cards/action.ts
+++ b/app/(pages)/(private)/(admin)/pending-cards/action.ts
@@ -2,7 +2,7 @@
 
 import { createUserRepository } from '@/repositories/userRepository';
 import { cryptography } from '@/services/cryptography';
-import { UserPendingData } from '@prisma/client';
+import { UserPendingData, UserStatus } from '@prisma/client';
 import { revalidatePath } from 'next/cache';
 
 export async function encryptUserPendingDataAction(
@@ -30,6 +30,13 @@ export async function encryptUserPendingDataAction(
 export async function deleteUserPendingDataAction(id: string) {
   const userRepository = createUserRepository();
   await userRepository.deletePendingData(id);
+
+  return revalidatePath('/pending-cards');
+}
+
+export async function updateUserStatusAction(id: string, status: UserStatus) {
+  const userRepository = createUserRepository();
+  await userRepository.updateStatus(id, status);
 
   return revalidatePath('/pending-cards');
 }

--- a/app/(pages)/(private)/(admin)/pending-cards/action.ts
+++ b/app/(pages)/(private)/(admin)/pending-cards/action.ts
@@ -3,6 +3,7 @@
 import { createUserRepository } from '@/repositories/userRepository';
 import { cryptography } from '@/services/cryptography';
 import { UserPendingData } from '@prisma/client';
+import { revalidatePath } from 'next/cache';
 
 export async function encryptUserPendingDataAction(
   userPendingData: UserPendingData,
@@ -24,4 +25,11 @@ export async function encryptUserPendingDataAction(
     data: { encryptedData, userEthAddress: user.ethAddress },
     error: null,
   };
+}
+
+export async function deleteUserPendingDataAction(id: string) {
+  const userRepository = createUserRepository();
+  await userRepository.deletePendingData(id);
+
+  return revalidatePath('/pending-cards');
 }

--- a/app/(pages)/(private)/(admin)/pending-cards/components/PendingTable.tsx
+++ b/app/(pages)/(private)/(admin)/pending-cards/components/PendingTable.tsx
@@ -9,6 +9,7 @@ import { useRouter } from 'next/navigation';
 import {
   deleteUserPendingDataAction,
   encryptUserPendingDataAction,
+  updateUserStatusAction,
 } from '../action';
 
 type PendingTableProps = {
@@ -169,6 +170,7 @@ function Actions({ userPendingData }: ActionsProps) {
       console.log({ result });
 
       await deleteUserPendingDataAction(userPendingData.id);
+      await updateUserStatusAction(userPendingData.userId, 'APPROVED');
     } catch (error) {
       // TODO: handle error
       console.log(error);

--- a/app/(pages)/(private)/(admin)/pending-cards/components/PendingTable.tsx
+++ b/app/(pages)/(private)/(admin)/pending-cards/components/PendingTable.tsx
@@ -6,7 +6,10 @@ import { ActionList, ActionMenu, Avatar, Box, Text } from '@primer/react';
 import { DataTable, Table } from '@primer/react/drafts';
 import { UserPendingData } from '@prisma/client';
 import { useRouter } from 'next/navigation';
-import { encryptUserPendingDataAction } from '../action';
+import {
+  deleteUserPendingDataAction,
+  encryptUserPendingDataAction,
+} from '../action';
 
 type PendingTableProps = {
   pendingCards: UserPendingData[];
@@ -165,7 +168,7 @@ function Actions({ userPendingData }: ActionsProps) {
 
       console.log({ result });
 
-      router.refresh();
+      await deleteUserPendingDataAction(userPendingData.id);
     } catch (error) {
       // TODO: handle error
       console.log(error);

--- a/app/(pages)/(private)/(admin)/pending-cards/page.tsx
+++ b/app/(pages)/(private)/(admin)/pending-cards/page.tsx
@@ -14,7 +14,16 @@ export default async function Page() {
   const pendingCards = await userRepository.findPendingUsers();
 
   if (pendingCards.length === 0) {
-    return <Text>Nenhuma solicitação de emissão de carteira pendente</Text>;
+    return (
+      <Text
+        sx={{
+          fontSize: 20,
+          color: 'slategray',
+        }}
+      >
+        Nenhuma solicitação de emissão de carteira pendente
+      </Text>
+    );
   }
 
   return (

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,6 +10,8 @@ export default async function Home() {
       <Text
         sx={{
           display: 'block',
+          fontSize: 20,
+          color: 'slategray',
         }}
       >
         Seja bem vindo ao site da Instituição X

--- a/prisma/migrations/20240928122645_renames_users_pending_data_table/migration.sql
+++ b/prisma/migrations/20240928122645_renames_users_pending_data_table/migration.sql
@@ -1,0 +1,35 @@
+/*
+  Warnings:
+
+  - You are about to drop the `(user_pending_data)` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "(user_pending_data)" DROP CONSTRAINT "(user_pending_data)_user_id_fkey";
+
+-- DropTable
+DROP TABLE "(user_pending_data)";
+
+-- CreateTable
+CREATE TABLE "users_pending_data" (
+    "id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "cpf" TEXT NOT NULL,
+    "cep" TEXT NOT NULL,
+    "address" TEXT NOT NULL,
+    "number" TEXT NOT NULL,
+    "complement" TEXT,
+    "course" TEXT NOT NULL,
+    "photo_url" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "users_pending_data_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "users_pending_data_user_id_key" ON "users_pending_data"("user_id");
+
+-- AddForeignKey
+ALTER TABLE "users_pending_data" ADD CONSTRAINT "users_pending_data_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -54,5 +54,5 @@ model UserPendingData {
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade, onUpdate: Cascade)
 
-  @@map("(user_pending_data)")
+  @@map("users_pending_data")
 }

--- a/repositories/userRepository.ts
+++ b/repositories/userRepository.ts
@@ -36,6 +36,7 @@ export function createUserRepository() {
     create,
     createPendingData,
     findPendingUsers,
+    deletePendingData,
   });
   type WithPassword = {
     withPassword?: boolean;
@@ -127,7 +128,18 @@ export function createUserRepository() {
       where: {
         user: {
           status: 'PENDING',
+          AND: {
+            role: 'USER',
+          },
         },
+      },
+    });
+  }
+
+  async function deletePendingData(id: string) {
+    return await prismaClient.userPendingData.delete({
+      where: {
+        id,
       },
     });
   }

--- a/repositories/userRepository.ts
+++ b/repositories/userRepository.ts
@@ -1,5 +1,5 @@
 import prismaClient from '@/lib/prismaClient';
-import { User } from '@prisma/client';
+import { User, UserStatus } from '@prisma/client';
 
 type CreateUserInput = {
   name: string;
@@ -37,6 +37,7 @@ export function createUserRepository() {
     createPendingData,
     findPendingUsers,
     deletePendingData,
+    updateStatus,
   });
   type WithPassword = {
     withPassword?: boolean;
@@ -93,6 +94,17 @@ export function createUserRepository() {
         id: true,
         name: true,
         email: true,
+      },
+    });
+  }
+
+  async function updateStatus(id: string, status: UserStatus) {
+    return await prismaClient.user.update({
+      where: {
+        id,
+      },
+      data: {
+        status,
       },
     });
   }

--- a/tests/repositories/userRepository.test.ts
+++ b/tests/repositories/userRepository.test.ts
@@ -155,4 +155,42 @@ describe('> User Repository', () => {
       },
     ]);
   });
+
+  it('should delete a pending user data', async () => {
+    const userRepository = createUserRepository();
+    const createdUser = await userRepository.create({
+      name: 'pending user to delete',
+      email: 'pendingtodelete@mail.com',
+      passwordHash: randomUUID(),
+      publicKey: randomUUID(),
+      ethAddress: randomUUID(),
+    });
+
+    const input = {
+      name: createdUser.name,
+      email: createdUser.email,
+      cpf: '12345678901',
+      cep: '12345678',
+      address: 'Rua Teste',
+      number: '123',
+      complement: 'Casa',
+      course: 'Ciência da Computação',
+      photoUrl: 'http://test.com/photo.jpg',
+    };
+
+    const createdUserPendingData = await userRepository.createPendingData(
+      createdUser.id,
+      input,
+    );
+
+    await userRepository.deletePendingData(createdUserPendingData.id);
+
+    const pendingUser = await prismaClient.userPendingData.findUnique({
+      where: {
+        id: createdUserPendingData.id,
+      },
+    });
+
+    expect(pendingUser).toBeNull();
+  });
 });

--- a/tests/repositories/userRepository.test.ts
+++ b/tests/repositories/userRepository.test.ts
@@ -193,4 +193,23 @@ describe('> User Repository', () => {
 
     expect(pendingUser).toBeNull();
   });
+
+  it('should update user status', async () => {
+    const userRepository = createUserRepository();
+    const createdUser = await userRepository.create({
+      name: 'user to update status',
+      email: 'emailtoupdatestatus@mail.com',
+      ethAddress: randomUUID(),
+      passwordHash: randomUUID(),
+      publicKey: randomUUID(),
+    });
+
+    const userBeforeUpdate = await userRepository.findById(createdUser.id);
+    expect(userBeforeUpdate?.status).toBe('PENDING');
+
+    await userRepository.updateStatus(createdUser.id, 'APPROVED');
+
+    const userAfterUpdate = await userRepository.findById(createdUser.id);
+    expect(userAfterUpdate?.status).toBe('APPROVED');
+  });
 });

--- a/utils/navItems.tsx
+++ b/utils/navItems.tsx
@@ -1,4 +1,5 @@
 import {
+  ChecklistIcon,
   HomeIcon,
   IdBadgeIcon,
   InfoIcon,
@@ -78,7 +79,7 @@ export const navItems: Array<NavItemProps> = [
   {
     title: 'Carteiras emitidas',
     href: '/issued-cards',
-    icon: <ListUnorderedIcon />,
+    icon: <ChecklistIcon />,
     auth: {
       isPrivate: true,
       onlyAdmin: true,


### PR DESCRIPTION
## Done
- renamed `user-pending-data` table
- changed some styles
- created `deletePendingData` function in `userRepository`
- created unit test to `deletePendingData`
- used `deletePendingData` function to delete data after approve te user (and emit its data to blockchain)
- created `updateStatus` in `userRepository` and test for it
- set user status to `APPROVED` after `issueCard`

## Preview
[Gravação de tela de 28-09-2024 11:27:09.webm](https://github.com/user-attachments/assets/574b2cd1-06b1-410e-8e16-73ac21ca436a)
