### PR TITLE
Implements complete functionality of reject user's card request (`admin`) and update card request (`user`) 

### DIFF
--- a/app/(pages)/(private)/(admin)/pending-cards/action.ts
+++ b/app/(pages)/(private)/(admin)/pending-cards/action.ts
@@ -50,3 +50,14 @@ export async function updateUserStatusAction(id: string, status: UserStatus) {
 
   return revalidatePath('/pending-cards');
 }
+
+export async function updateUserRejectionReasonAction(
+  id: string,
+  rejection_reason: string,
+) {
+  const userRepository = createUserRepository();
+  await userRepository.updatePendingData({
+    id,
+    rejection_reason,
+  });
+}

--- a/app/(pages)/(private)/student-card/status/page.tsx
+++ b/app/(pages)/(private)/student-card/status/page.tsx
@@ -1,11 +1,25 @@
+import { createUserRepository } from '@/repositories/userRepository';
 import { identity } from '@/utils/idendity';
 import { Box, Label, Text } from '@primer/react';
+import { revalidatePath } from 'next/cache';
+import Link from 'next/link';
 import { redirect, RedirectType } from 'next/navigation';
 
 export default async function Page() {
   const signedUser = await identity.isLoggedIn();
   if (!signedUser || signedUser.role === 'ADMIN') {
     return redirect('/', RedirectType.replace);
+  }
+
+  let rejectionReason = '';
+  if (signedUser.status === 'REJECTED') {
+    const userRepository = createUserRepository();
+    const pendingUserData = await userRepository.findPendingDataByUserId(
+      signedUser.id,
+    );
+
+    rejectionReason = pendingUserData?.rejection_reason ?? '';
+    revalidatePath('/student-card/status');
   }
 
   const statusObject = {
@@ -19,23 +33,41 @@ export default async function Page() {
       sx={{
         height: '100%',
         display: 'flex',
+        flexDirection: 'column',
         alignItems: 'center',
         justifyContent: 'center',
         gap: 2,
       }}
     >
-      <Text>Status da carteira:</Text>
-      <Label
-        variant={
-          signedUser.status === 'APPROVED'
-            ? 'success'
-            : signedUser.status === 'REJECTED'
-              ? 'danger'
-              : 'attention'
-        }
-      >
-        {statusObject[signedUser.status]}
-      </Label>
+      <Box>
+        <Text sx={{ mr: 2 }}>Status da carteira:</Text>
+        <Label
+          size="large"
+          variant={
+            signedUser.status === 'APPROVED'
+              ? 'success'
+              : signedUser.status === 'REJECTED'
+                ? 'danger'
+                : 'attention'
+          }
+        >
+          {statusObject[signedUser.status]}
+        </Label>
+      </Box>
+
+      {signedUser.status === 'REJECTED' && (
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 2,
+          }}
+        >
+          <Text sx={{ mr: 2 }}>Justificativa: {rejectionReason}</Text>
+
+          <Link href="/update-profile">Atualizar informações</Link>
+        </Box>
+      )}
     </Box>
   );
 }

--- a/app/(pages)/(private)/update-profile/action.ts
+++ b/app/(pages)/(private)/update-profile/action.ts
@@ -1,0 +1,35 @@
+'use server';
+
+import { createUserRepository } from '@/repositories/userRepository';
+import { lambda as lambdaService } from '@/services/lambda';
+import {
+  createEditPendingDataUseCase,
+  EditPendingDataUseCaseInput,
+} from '@/useCases/editPendingDataUseCase';
+import { revalidatePath } from 'next/cache';
+
+export async function tryToUpdateUserPendingDataAction(
+  _state: unknown,
+  formData: FormData,
+) {
+  const userRepository = createUserRepository();
+  const { editPendingDataUseCase } = createEditPendingDataUseCase(
+    lambdaService,
+    userRepository,
+  );
+
+  const data = Object.fromEntries(
+    formData.entries(),
+  ) as EditPendingDataUseCaseInput & {
+    userId: string;
+  };
+
+  const response = await editPendingDataUseCase(data);
+  if (response.data) {
+    await userRepository.updateStatus(data.userId, 'PENDING');
+  }
+
+  revalidatePath('/update-profile');
+
+  return response;
+}

--- a/app/(pages)/(private)/update-profile/components/EditUserRegisterForm.tsx
+++ b/app/(pages)/(private)/update-profile/components/EditUserRegisterForm.tsx
@@ -1,0 +1,143 @@
+'use client';
+
+import { CustomInput } from '@/app/components/CustomInput';
+import { CustomSelect } from '@/app/components/CustomSelect';
+import { LoadingButton } from '@/app/components/LoadingButton';
+import { Avatar, Text } from '@primer/react';
+import { UserPendingData } from '@prisma/client';
+import { useFormState } from 'react-dom';
+import { tryToUpdateUserPendingDataAction } from '../action';
+
+type EditUserRegisterFormProps = {
+  userPendingData: UserPendingData | null;
+};
+
+export function EditUserRegisterForm({
+  userPendingData,
+}: EditUserRegisterFormProps) {
+  const [state, action] = useFormState(tryToUpdateUserPendingDataAction, null);
+
+  function getErrorMessage(path: string) {
+    return state?.errors?.find((error) => error.path.includes(path))?.message;
+  }
+
+  return (
+    <form
+      action={action}
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 2,
+        maxWidth: 400,
+        width: '100%',
+      }}
+    >
+      {userPendingData?.photoUrl && (
+        <Avatar
+          sx={{
+            width: 50,
+            height: 50,
+          }}
+          src={userPendingData.photoUrl}
+          alt="Foto do aluno"
+        />
+      )}
+      <Text
+        sx={{
+          mb: 2,
+        }}
+      >
+        Sobre o aluno: {userPendingData?.name}
+        <br />
+        email: {userPendingData?.email}
+      </Text>
+
+      <input name="id" type="hidden" defaultValue={userPendingData!.id} />
+      <input
+        name="userId"
+        type="hidden"
+        defaultValue={userPendingData!.userId}
+      />
+
+      <CustomInput
+        label="CPF"
+        name="cpf"
+        type="number"
+        required
+        defaultValue={userPendingData?.cpf}
+        error={getErrorMessage('cpf')}
+      />
+      <CustomInput
+        label="Cep"
+        name="cep"
+        type="number"
+        required
+        defaultValue={userPendingData?.cep}
+        error={getErrorMessage('cep')}
+      />
+      <CustomInput
+        label="Endereço"
+        name="address"
+        required
+        defaultValue={userPendingData?.address}
+        error={getErrorMessage('address')}
+      />
+      <CustomInput
+        label="Número"
+        name="number"
+        type="number"
+        required
+        defaultValue={userPendingData?.number}
+        error={getErrorMessage('number')}
+      />
+      <CustomInput
+        label="Complemento"
+        name="complement"
+        defaultValue={userPendingData?.complement ?? ''}
+        error={getErrorMessage('complement')}
+      />
+
+      <label
+        htmlFor="course"
+        style={{ fontWeight: 'bold', cursor: 'pointer', fontSize: 14 }}
+      >
+        Curso desejado
+      </label>
+      <CustomSelect
+        id="course"
+        name="course"
+        required
+        defaultValue={userPendingData?.course}
+        options={[
+          { value: '', label: '' },
+          { value: 'ciencia-da-computacao', label: 'Ciência da Computação' },
+          {
+            value: 'engenharia-de-software',
+            label: 'Engenharia de Software',
+          },
+          {
+            value: 'sistemas-de-informacao',
+            label: 'Sistemas de Informação',
+          },
+        ]}
+      />
+
+      <label
+        htmlFor="photo"
+        style={{ fontWeight: 'bold', cursor: 'pointer', fontSize: 14 }}
+      >
+        Foto do aluno
+      </label>
+      <input
+        type="file"
+        name="photo"
+        id="photo"
+        accept="image/png, image/jpg, image/jpeg"
+      />
+
+      <LoadingButton>
+        Atualizar dados e solicitar matrícula novamente
+      </LoadingButton>
+    </form>
+  );
+}

--- a/app/(pages)/(private)/update-profile/page.tsx
+++ b/app/(pages)/(private)/update-profile/page.tsx
@@ -1,0 +1,36 @@
+import { createUserRepository } from '@/repositories/userRepository';
+import { identity } from '@/utils/idendity';
+import { Box } from '@primer/react';
+import { redirect, RedirectType } from 'next/navigation';
+import { EditUserRegisterForm } from './components/EditUserRegisterForm';
+
+export default async function Page() {
+  const signedUser = await identity.isLoggedIn();
+  if (
+    !signedUser ||
+    signedUser.status !== 'REJECTED' ||
+    signedUser.role == 'ADMIN'
+  ) {
+    return redirect('/', RedirectType.replace);
+  }
+
+  const userRepository = createUserRepository();
+  const userPendingData = await userRepository.findPendingDataByUserId(
+    signedUser.id,
+  );
+
+  return (
+    <Box
+      sx={{
+        height: '100%',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        flexDirection: 'column',
+        overflowY: 'auto',
+      }}
+    >
+      <EditUserRegisterForm userPendingData={userPendingData} />
+    </Box>
+  );
+}

--- a/app/components/CustomInput.tsx
+++ b/app/components/CustomInput.tsx
@@ -18,8 +18,6 @@ export function CustomInput({
 }: CustomInputProps) {
   const inputId = id || name;
 
-  console.log({ required });
-
   return (
     <FormControl
       id={inputId}

--- a/app/ui/Sidebar.tsx
+++ b/app/ui/Sidebar.tsx
@@ -6,6 +6,7 @@ import { NavListItem } from '../components/NavListItem';
 export async function Sidebar() {
   const userSignedIn = await identity.isLoggedIn();
   const isUserAdmin = userSignedIn && userSignedIn.role === 'ADMIN';
+  const isUserRejected = userSignedIn && userSignedIn.status === 'REJECTED';
 
   return (
     <Box
@@ -33,6 +34,7 @@ export async function Sidebar() {
           if (userSignedIn && item.auth.onlyNotSignedIn) return null;
           if (!isUserAdmin && item.auth.onlyAdmin) return null;
           if (isUserAdmin && item.auth.onlyStudent) return null;
+          if (!isUserRejected && item.href === '/update-profile') return null;
 
           return <NavListItem key={item.href} item={item} />;
         })}

--- a/prisma/migrations/20240930232701_adds_reject_reason_fiel_d_in_pending_table/migration.sql
+++ b/prisma/migrations/20240930232701_adds_reject_reason_fiel_d_in_pending_table/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "users_pending_data" ADD COLUMN     "rejection_reason" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -39,18 +39,19 @@ model User {
 }
 
 model UserPendingData {
-  id         String   @id @default(uuid())
-  userId     String   @unique @map("user_id")
-  name       String
-  email      String
-  cpf        String
-  cep        String
-  address    String
-  number     String
-  complement String?
-  course     String
-  photoUrl   String   @map("photo_url")
-  createdAt  DateTime @default(now()) @map("created_at")
+  id               String   @id @default(uuid())
+  userId           String   @unique @map("user_id")
+  name             String
+  email            String
+  cpf              String
+  cep              String
+  address          String
+  number           String
+  complement       String?
+  course           String
+  photoUrl         String   @map("photo_url")
+  rejection_reason String?  @map("rejection_reason")
+  createdAt        DateTime @default(now()) @map("created_at")
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade, onUpdate: Cascade)
 

--- a/repositories/userRepository.ts
+++ b/repositories/userRepository.ts
@@ -27,6 +27,18 @@ type CreatePendingDataInput = {
   photoUrl: string;
 };
 
+export type EditPendingDataInput = {
+  id: string;
+  cpf?: string;
+  cep?: string;
+  address?: string;
+  number?: string;
+  complement?: string;
+  course?: string;
+  photoUrl?: string;
+  rejection_reason?: string;
+};
+
 export type UserRepository = ReturnType<typeof createUserRepository>;
 
 export function createUserRepository() {
@@ -38,6 +50,8 @@ export function createUserRepository() {
     findPendingUsers,
     deletePendingData,
     updateStatus,
+    updatePendingData,
+    findPendingDataByUserId,
   });
   type WithPassword = {
     withPassword?: boolean;
@@ -148,10 +162,30 @@ export function createUserRepository() {
     });
   }
 
+  async function findPendingDataByUserId(id: string) {
+    return await prismaClient.userPendingData.findUnique({
+      where: {
+        userId: id,
+      },
+    });
+  }
+
   async function deletePendingData(id: string) {
     return await prismaClient.userPendingData.delete({
       where: {
         id,
+      },
+    });
+  }
+
+  async function updatePendingData(input: EditPendingDataInput) {
+    const { id, ...data } = input;
+    return await prismaClient.userPendingData.update({
+      where: {
+        id,
+      },
+      data: {
+        ...data,
       },
     });
   }

--- a/tests/repositories/userRepository.test.ts
+++ b/tests/repositories/userRepository.test.ts
@@ -151,6 +151,7 @@ describe('> User Repository', () => {
         complement: 'Casa',
         course: 'Ciência da Computação',
         photoUrl: 'http://test.com/photo.jpg',
+        rejection_reason: null,
         createdAt: expect.any(Date),
       },
     ]);

--- a/useCases/editPendingDataUseCase.ts
+++ b/useCases/editPendingDataUseCase.ts
@@ -1,0 +1,118 @@
+import {
+  EditPendingDataInput,
+  UserRepository,
+} from '@/repositories/userRepository';
+import { LambdaService } from '@/services/lambda';
+import { z } from 'zod';
+
+export type EditPendingDataUseCaseInput = Omit<
+  EditPendingDataInput,
+  'photoUrl'
+> & {
+  photo?: File;
+};
+
+export function createEditPendingDataUseCase(
+  lambdaService: LambdaService,
+  userRepository: UserRepository,
+) {
+  return Object.freeze({
+    editPendingDataUseCase,
+  });
+
+  async function editPendingDataUseCase(input: EditPendingDataUseCaseInput) {
+    const validationResult = schema.safeParse(input);
+    if (validationResult.error) {
+      return {
+        errors: validationResult.error.issues,
+        data: null,
+      };
+    }
+
+    const { photo, ...pendingData } = input;
+
+    let newFileUrl = '';
+    if (input.photo && input.photo.size > 0) {
+      const { file_url } = await lambdaService.uploadFile(input.photo);
+      newFileUrl = file_url;
+    }
+
+    const editedPendingData: EditPendingDataInput = {
+      ...pendingData,
+    };
+
+    if (newFileUrl) {
+      editedPendingData.photoUrl = newFileUrl;
+    }
+    await userRepository.updatePendingData(editedPendingData);
+
+    return {
+      errors: null,
+      data: {
+        message: 'Dados atualizados com sucesso.',
+      },
+    };
+  }
+}
+
+const schema = z.object({
+  cpf: z
+    .string({
+      invalid_type_error: 'O campo cpf deve ser uma string',
+      required_error: 'O campo cpf é obrigatório',
+    })
+    .length(11, {
+      message: 'O campo cpf deve ter 11 caracteres',
+    })
+    .regex(/^\d+$/, {
+      message: 'O campo cpf deve conter apenas números',
+    }),
+  cep: z
+    .string({
+      invalid_type_error: 'O campo cep deve ser uma string',
+      required_error: 'O campo cep é obrigatório',
+    })
+    .length(8, {
+      message: 'O campo cep deve ter 8 caracteres',
+    })
+    .regex(/^\d+$/, {
+      message: 'O campo cep deve conter apenas números',
+    }),
+  address: z
+    .string({
+      invalid_type_error: 'O campo endereço deve ser uma string',
+      required_error: 'O campo endereço é obrigatório',
+    })
+    .min(3, {
+      message: 'O campo endereço deve ter no mínimo 3 caracteres',
+    }),
+  number: z
+    .string({
+      invalid_type_error: 'O campo número deve ser uma string',
+      required_error: 'O campo número é obrigatório',
+    })
+    .regex(/^\d+$/, {
+      message: 'O campo número deve conter apenas números',
+    }),
+  complement: z
+    .string({
+      invalid_type_error: 'O campo complemento deve ser uma string',
+    })
+    .optional(),
+  course: z
+    .string({
+      invalid_type_error: 'O campo curso deve ser uma string',
+      required_error: 'O campo curso é obrigatório',
+    })
+    .refine(
+      (value) =>
+        [
+          'ciencia-da-computacao',
+          'engenharia-de-software',
+          'sistemas-de-informacao',
+        ].includes(value),
+      {
+        message: 'O campo curso deve ser uma das opções disponíveis',
+      },
+    ),
+});

--- a/utils/navItems.tsx
+++ b/utils/navItems.tsx
@@ -85,4 +85,13 @@ export const navItems: Array<NavItemProps> = [
       onlyAdmin: true,
     },
   },
+  {
+    title: 'Alterar cadastro',
+    href: '/update-profile',
+    icon: <PersonIcon />,
+    auth: {
+      isPrivate: true,
+      onlyStudent: true,
+    },
+  },
 ];


### PR DESCRIPTION
## Context
- This PR implements the full `reject user card request` functionality.
- It also implements the user side, in the sense of updating their request based on the feedback provided by the admin

## Done
- added `rejection_field` column in `users_pending_data` table
- created `findPendingDataByUserId` and `updatePendingData` functions
- implemented admin functionality of reject user's card request
- implemented page to `change user's data` if admin rejects the card
- created `editPendingDataUseCase`
- showed `rejection_reason` in the user status page if card request is `REJECTED`

## Preview
[rejeitar-carteira.webm](https://github.com/user-attachments/assets/ba27f7e5-1333-44cd-a431-3b2b3c899e89)
