### PR TITLE
Improves codestyle of `reject user request` flow and creates tests for previous implementations

### DIFF
--- a/app/(pages)/(private)/(admin)/pending-cards/action.ts
+++ b/app/(pages)/(private)/(admin)/pending-cards/action.ts
@@ -58,6 +58,8 @@ export async function updateUserRejectionReasonAction(
   const userRepository = createUserRepository();
   await userRepository.updatePendingData({
     id,
-    rejection_reason,
+    dataToUpdate: {
+      rejection_reason,
+    },
   });
 }

--- a/app/(pages)/(private)/update-profile/components/EditUserRegisterForm.tsx
+++ b/app/(pages)/(private)/update-profile/components/EditUserRegisterForm.tsx
@@ -52,11 +52,20 @@ export function EditUserRegisterForm({
         email: {userPendingData?.email}
       </Text>
 
-      <input name="id" type="hidden" defaultValue={userPendingData!.id} />
+      <input
+        name="pendingDataId"
+        type="hidden"
+        defaultValue={userPendingData!.id}
+      />
       <input
         name="userId"
         type="hidden"
         defaultValue={userPendingData!.userId}
+      />
+      <input
+        name="photoUrl"
+        type="hidden"
+        defaultValue={userPendingData!.photoUrl}
       />
 
       <CustomInput

--- a/repositories/userRepository.ts
+++ b/repositories/userRepository.ts
@@ -27,16 +27,18 @@ type CreatePendingDataInput = {
   photoUrl: string;
 };
 
-export type EditPendingDataInput = {
+export type UpdatePendingDataInput = {
   id: string;
-  cpf?: string;
-  cep?: string;
-  address?: string;
-  number?: string;
-  complement?: string;
-  course?: string;
-  photoUrl?: string;
-  rejection_reason?: string;
+  dataToUpdate?: {
+    cpf?: string;
+    cep?: string;
+    address?: string;
+    number?: string;
+    complement?: string;
+    course?: string;
+    photoUrl?: string;
+    rejection_reason?: string;
+  };
 };
 
 export type UserRepository = ReturnType<typeof createUserRepository>;
@@ -178,14 +180,19 @@ export function createUserRepository() {
     });
   }
 
-  async function updatePendingData(input: EditPendingDataInput) {
-    const { id, ...data } = input;
+  async function updatePendingData(input: UpdatePendingDataInput) {
+    const { id, dataToUpdate } = input;
+
+    if (!dataToUpdate || Object.keys(dataToUpdate).length === 0) {
+      return null;
+    }
+
     return await prismaClient.userPendingData.update({
       where: {
         id,
       },
       data: {
-        ...data,
+        ...dataToUpdate,
       },
     });
   }

--- a/tests/repositories/userRepository.test.ts
+++ b/tests/repositories/userRepository.test.ts
@@ -213,4 +213,97 @@ describe('> User Repository', () => {
     const userAfterUpdate = await userRepository.findById(createdUser.id);
     expect(userAfterUpdate?.status).toBe('APPROVED');
   });
+
+  it('should retrieve user pending data by userId', async () => {
+    const userRepository = createUserRepository();
+    const createdUser = await userRepository.create({
+      name: 'user_to_retrieve_pending_data',
+      email: 'user_to_retrieve_pending_data@mail.com',
+      ethAddress: randomUUID(),
+      passwordHash: randomUUID(),
+      publicKey: randomUUID(),
+    });
+
+    const randomCpf = randomBytes(11).toString('base64url');
+    const randomCep = randomBytes(8).toString('base64url');
+
+    const createdPendingData = await userRepository.createPendingData(
+      createdUser.id,
+      {
+        name: createdUser.name,
+        email: createdUser.email,
+        cpf: randomCpf,
+        cep: randomCep,
+        address: 'Test',
+        course: 'Ciência da Computação',
+        number: '123',
+        photoUrl: 'http://test.com/photo.jpg',
+      },
+    );
+
+    const pendingDataByUserId = await userRepository.findPendingDataByUserId(
+      createdUser.id,
+    );
+
+    expect(pendingDataByUserId).toStrictEqual({
+      id: createdPendingData.id,
+      userId: createdPendingData.userId,
+      name: createdPendingData.name,
+      email: createdPendingData.email,
+      cpf: randomCpf,
+      cep: randomCep,
+      complement: null,
+      address: 'Test',
+      number: '123',
+      course: 'Ciência da Computação',
+      photoUrl: 'http://test.com/photo.jpg',
+      rejection_reason: null,
+      createdAt: expect.any(Date),
+    });
+  });
+
+  it('should update user pending data', async () => {
+    const userRepository = createUserRepository();
+    const createdUser = await userRepository.create({
+      name: 'user_to_update_pending_data',
+      email: 'user_to_update_pending_data@mail.com',
+      ethAddress: randomUUID(),
+      passwordHash: randomUUID(),
+      publicKey: randomUUID(),
+    });
+
+    const randomCpf = randomBytes(11).toString('base64url');
+    const randomCep = randomBytes(8).toString('base64url');
+
+    const createdPendingData = await userRepository.createPendingData(
+      createdUser.id,
+      {
+        name: createdUser.name,
+        email: createdUser.email,
+        cpf: randomCpf,
+        cep: randomCep,
+        address: 'Test',
+        course: 'Ciência da Computação',
+        number: '123',
+        photoUrl: 'http://test.com/photo.jpg',
+      },
+    );
+
+    const dataBeforeUpdate = await userRepository.findPendingDataByUserId(
+      createdPendingData.userId,
+    );
+    expect(dataBeforeUpdate?.address).toBe('Test');
+
+    await userRepository.updatePendingData({
+      id: createdPendingData.id,
+      dataToUpdate: {
+        address: 'Rua Teste',
+      },
+    });
+
+    const dataAfterUpdate = await userRepository.findPendingDataByUserId(
+      createdPendingData.userId,
+    );
+    expect(dataAfterUpdate?.address).toBe('Rua Teste');
+  });
 });

--- a/tests/useCases/updatePendingDataUseCase.test.ts
+++ b/tests/useCases/updatePendingDataUseCase.test.ts
@@ -1,0 +1,57 @@
+import prismaClient from '@/lib/prismaClient';
+import { createUserRepository } from '@/repositories/userRepository';
+import { createUpdatePendingDataUseCase } from '@/useCases/updatePendingDataUseCase';
+import { randomUUID } from 'crypto';
+
+beforeAll(async () => {
+  await prismaClient.user.deleteMany();
+});
+
+describe('> Update Pending Data Use Case', () => {
+  it('should return a error when send at lead one invalid input field', async () => {
+    const userRepository = createUserRepository();
+    const { updatePendingDataUseCase } =
+      createUpdatePendingDataUseCase(userRepository);
+
+    const createdUser = await userRepository.create({
+      name: 'user_to_update_use_case',
+      email: 'user_to_update_use_case@mail.com',
+      ethAddress: randomUUID(),
+      passwordHash: randomUUID(),
+      publicKey: randomUUID(),
+    });
+
+    const createdPendingData = await userRepository.createPendingData(
+      createdUser.id,
+      {
+        name: createdUser.name,
+        email: createdUser.email,
+        address: 'Test',
+        cep: '12345678',
+        cpf: '12345678911',
+        course: 'ciencia-da-computacao',
+        number: '123',
+        complement: 'Complement',
+        photoUrl: 'https://test.com/photo.jpg',
+      },
+    );
+
+    // The input will always expect a full object because it will
+    // be provided by the form data (update-profile).
+    const updatedPendingDat = await updatePendingDataUseCase({
+      id: createdPendingData.id,
+      dataToUpdate: {
+        address: 'Test',
+        cep: '12345678',
+        cpf: '12345678911',
+        course: 'invalid-course',
+        number: '123',
+        complement: 'Complement',
+        photoUrl: 'https://test.com/photo.jpg',
+      },
+    });
+
+    expect(updatedPendingDat.data).toBeNull();
+    expect(updatedPendingDat.errors![0].path).toStrictEqual(['course']);
+  });
+});


### PR DESCRIPTION
## Context
- This PR aims to improve the code and adjusts some complex flows that was implemented on [this PR](https://github.com/SouzaGabriel26/student-identification/pull/60)

## Done
- refactored `pendingDataUseCase` renaming from `editPendingDataUseCase` to `updatePendingDataUseCase`
- refactored `/update-profile` page handling `file upload` (if necessary) before call `updatePendingDataUseCase` in server actions
- refactored `userRepository` changing `updatePendingData` input type
- created tests for:
  - `findPendingDataByUserId` (userRepository)
  - `updatePendingData` (userRepository)
  - `updatePendingDataUseCase` (useCases)
 
 ## To do
- fix bug on `approve card`: when trying to encrypt user data