### PR TITLE
Limits length of data to encrypt with RSA algorithm in `encryptData`

### DIFF
--- a/app/(pages)/(private)/(admin)/pending-cards/action.ts
+++ b/app/(pages)/(private)/(admin)/pending-cards/action.ts
@@ -16,10 +16,12 @@ export async function encryptUserPendingDataAction(
       error: 'Falha ao encontrar usuário',
     };
 
-  const { encryptedData } = cryptography.encryptData({
+  const { encryptedData, error } = cryptography.encryptData({
     data: userPendingData,
     publicKey: user.publicKey,
   });
+
+  if (error) return { data: null, error };
 
   return {
     data: { encryptedData, userEthAddress: user.ethAddress },

--- a/app/(pages)/(private)/(admin)/pending-cards/components/PendingTable.tsx
+++ b/app/(pages)/(private)/(admin)/pending-cards/components/PendingTable.tsx
@@ -151,8 +151,8 @@ function Actions({ userPendingData }: ActionsProps) {
     const { data, error } = await encryptUserPendingDataAction(userPendingData);
 
     if (!data) {
-      // TODO: handle error
-      console.log(error);
+      setErrorMessage(error);
+      setIsDialogOpen(true);
       return;
     }
 

--- a/contract/contract-address.ts
+++ b/contract/contract-address.ts
@@ -1,1 +1,1 @@
-export const contractAddress = '0xdD9b26941d35553B6F51F3299487E877Ce7757F2';
+export const contractAddress = '0x949D5FDb43517e3b2cb614854f19eDc8BA660763';

--- a/services/cryptography.ts
+++ b/services/cryptography.ts
@@ -42,6 +42,13 @@ type EncryptDataProps<T> = {
 };
 
 function encryptData<Data>({ data, publicKey }: EncryptDataProps<Data>) {
+  const stringifiedData = JSON.stringify(data);
+  if (stringifiedData.length > 470) {
+    return {
+      error: 'O tamanho do objeto é muito grande para ser criptografado.',
+    };
+  }
+
   const bufferData = Buffer.from(JSON.stringify(data), 'utf8');
   const encryptedData = crypto.publicEncrypt(publicKey, bufferData);
   return { encryptedData: encryptedData.toString('base64') };

--- a/tests/services/cryptography.test.ts
+++ b/tests/services/cryptography.test.ts
@@ -27,6 +27,22 @@ describe('> models/cryptography', () => {
     });
   });
 
+  test('Invoking encryptData with a object that has more than 470 characters', () => {
+    const { publicKey } = cryptography.generateKeyPairs({
+      passphrase: 'secret',
+    });
+
+    const description = 'a'.repeat(470);
+    const result = cryptography.encryptData({
+      data: description,
+      publicKey,
+    });
+
+    expect(result).toStrictEqual({
+      error: 'O tamanho do objeto é muito grande para ser criptografado.',
+    });
+  });
+
   test('Invoking "decryptData"', () => {
     const data = { name: 'Jane Doe', age: 25 };
     const passphrase = 'password123';
@@ -42,7 +58,7 @@ describe('> models/cryptography', () => {
     expect(typeof encryptedData).toBe('string');
 
     const result = cryptography.decryptData({
-      encryptedData,
+      encryptedData: encryptedData!,
       privateKey,
       passphrase,
     });
@@ -66,7 +82,7 @@ describe('> models/cryptography', () => {
     });
 
     const result = cryptography.decryptData({
-      encryptedData,
+      encryptedData: encryptedData!,
       privateKey,
       passphrase: 'wrong-password',
     });


### PR DESCRIPTION
## Context
- This PR addresses an issue where an error occurs when attempting to encrypt data that exceeds the size supported by RSA keys. The error reported was:

```ts
public encrypt Error: error:0200006E:rsa routines::data too large for key size
```
This error occurs because the RSA encryption algorithm has a maximum limit on the amount of data that can be directly encrypted, based on the key size (in this case, 4096 bits) and the padding scheme used (PKCS#1 v1.5). Attempting to encrypt data larger than this limit results in failure, causing the mentioned error.

## Preview
[Gravação de tela de 02-10-2024 22:25:07.webm](https://github.com/user-attachments/assets/30b8a512-30a6-4feb-9960-af1985434dba)
