### PR TITLE
Integrates `invalidateCard` smart contract function with project

### DIFF
--- a/app/(pages)/(private)/student-card/components/StudentCard.tsx
+++ b/app/(pages)/(private)/student-card/components/StudentCard.tsx
@@ -142,7 +142,10 @@ export function StudentCard({ ethAddress }: StudentCardProps) {
           marginTop: 4,
         }}
       >
-        <Button onClick={() => setIsDialogOpen(true)}>
+        <Button
+          disabled={!ethStudentCard?.isValid}
+          onClick={() => setIsDialogOpen(true)}
+        >
           Descriptografar carteira
         </Button>
 


### PR DESCRIPTION
## Context
- Now admin users can `invalidate` students card
- If the card is valid, it will have a green border
- If the card is invalid or expired, it will have a red border

## Preview
[Gravação de tela de 03-10-2024 21:55:57.webm](https://github.com/user-attachments/assets/3505af0e-f019-4c4b-939d-fc4b4066259b)


## Todo
- Create a flow to emit another card if the student request (forget privateKey):
  - invalidate actual card (by public key)
  - redirect user to fill up a register form (again)
  - generate another RSA keyPairs (and a ethPublicKey based on RSA public key)
  - make the entire flow of `issueCard` again (hash data with publicKey, call `issueData`, etc)