### PR TITLE
Adjusts project structure to accept `forgot private key` functionality

### DIFF
--- a/app/(pages)/(private)/student-card/action.ts
+++ b/app/(pages)/(private)/student-card/action.ts
@@ -1,7 +1,9 @@
 'use server';
 
+import { createUserRepository } from '@/repositories/userRepository';
 import { cryptography, DecryptDataProps } from '@/services/cryptography';
-import { UserPendingData } from '@prisma/client';
+import { UserPendingData, UserStatus } from '@prisma/client';
+import { redirect } from 'next/navigation';
 
 export async function decryptUserDataAction({
   encryptedData,
@@ -35,9 +37,12 @@ export async function decryptUserDataAction({
   };
 }
 
-export async function forgotPrivateKeyAction(
-  _state: unknown,
-  userEthAddress: string,
-) {
-  console.log({ userEthAddress });
+export async function updateUserStatusAction(payload: {
+  userId: string;
+  status: UserStatus;
+}) {
+  const userRepository = createUserRepository();
+
+  await userRepository.updateStatus(payload.userId, payload.status);
+  return redirect('/student-card/status');
 }

--- a/app/(pages)/(private)/student-card/components/ForgotPrivateKeyForm.tsx
+++ b/app/(pages)/(private)/student-card/components/ForgotPrivateKeyForm.tsx
@@ -1,22 +1,35 @@
 'use client';
 
 import { LoadingButton } from '@/app/components/LoadingButton';
+import { useWeb3Context } from '@/app/contexts/Web3Context';
 import { Box, Button, Dialog, Label, Text } from '@primer/react';
 import { Divider } from '@primer/react/lib-esm/ActionList/Divider';
 import { useState } from 'react';
-import { useFormState } from 'react-dom';
-import { forgotPrivateKeyAction } from '../action';
+import { updateUserStatusAction } from '../action';
 
 type ForgotPrivateKeyFormProps = {
   ethAddress: string;
+  userId: string;
 };
 
 export function ForgotPrivateKeyForm({
   ethAddress,
+  userId,
 }: ForgotPrivateKeyFormProps) {
-  const [_, action] = useFormState(forgotPrivateKeyAction, null);
   const [isForgotPrivateKeyModalOpen, setIsForgotPrivateKeyModalOpen] =
     useState(false);
+
+  const { account, contract } = useWeb3Context();
+
+  async function handleForgotPrivateKey() {
+    if (!contract || !account) return;
+
+    await contract.methods.invalidateCard(ethAddress).send({ from: account });
+
+    updateUserStatusAction({ status: 'FORGOT_PK', userId });
+
+    setIsForgotPrivateKeyModalOpen(false);
+  }
 
   return (
     <Box>
@@ -103,7 +116,7 @@ export function ForgotPrivateKeyForm({
             <LoadingButton
               sx={{ mt: 0 }}
               variant="primary"
-              onClick={() => action(ethAddress)}
+              onClick={handleForgotPrivateKey}
             >
               Proseguir
             </LoadingButton>

--- a/app/(pages)/(private)/student-card/components/StudentCard.tsx
+++ b/app/(pages)/(private)/student-card/components/StudentCard.tsx
@@ -24,6 +24,7 @@ import { ForgotPrivateKeyForm } from './ForgotPrivateKeyForm';
 
 type StudentCardProps = {
   ethAddress: string;
+  userId: string;
 };
 
 type Card = {
@@ -33,7 +34,7 @@ type Card = {
   isValid: boolean;
 };
 
-export function StudentCard({ ethAddress }: StudentCardProps) {
+export function StudentCard({ ethAddress, userId }: StudentCardProps) {
   const [cardNotFoundError, setCardNotFoundError] = useState('');
   const [ethStudentCard, setEthStudentCard] = useState<Card | null>(null);
   const [decryptedStudentCard, setDecryptedStudentCard] =
@@ -127,7 +128,7 @@ export function StudentCard({ ethAddress }: StudentCardProps) {
             }}
           >
             <DecryptStudentCardForm />
-            <ForgotPrivateKeyForm ethAddress={ethAddress} />
+            <ForgotPrivateKeyForm ethAddress={ethAddress} userId={userId} />
           </Box>
         </>
       )}

--- a/app/(pages)/(private)/student-card/page.tsx
+++ b/app/(pages)/(private)/student-card/page.tsx
@@ -28,7 +28,7 @@ export default async function Page() {
 
   return (
     <Web3Provider>
-      <StudentCard ethAddress={signedUser.ethAddress} />
+      <StudentCard ethAddress={signedUser.ethAddress} userId={signedUser.id} />
     </Web3Provider>
   );
 }

--- a/app/(pages)/(private)/student-card/status/page.tsx
+++ b/app/(pages)/(private)/student-card/status/page.tsx
@@ -1,6 +1,7 @@
 import { createUserRepository } from '@/repositories/userRepository';
 import { identity } from '@/utils/idendity';
 import { Box, Label, Text } from '@primer/react';
+import { UserStatus } from '@prisma/client';
 import { revalidatePath } from 'next/cache';
 import Link from 'next/link';
 import { redirect, RedirectType } from 'next/navigation';
@@ -22,10 +23,11 @@ export default async function Page() {
     revalidatePath('/student-card/status');
   }
 
-  const statusObject = {
+  const statusObject: Record<UserStatus, string> = {
     APPROVED: 'Aprovado',
     REJECTED: 'Rejeitado',
     PENDING: 'Pendente',
+    FORGOT_PK: 'Esqueceu a chave privada',
   };
 
   return (
@@ -66,6 +68,29 @@ export default async function Page() {
           <Text sx={{ mr: 2 }}>Justificativa: {rejectionReason}</Text>
 
           <Link href="/update-profile">Atualizar informações</Link>
+        </Box>
+      )}
+
+      {signedUser.status === 'FORGOT_PK' && (
+        <Box>
+          <Text>
+            Você esqueceu a chave privada. Para gerar uma nova carteira, siga os
+            seguintes passos:
+          </Text>
+
+          <ol>
+            <li>
+              preencha novamente o
+              <Link href="/update-profile"> formulário </Link>
+              com seus dados.
+            </li>
+
+            <li>Envie o formulário.</li>
+
+            <li>Guarde sua chave nova chave privada em um local seguro.</li>
+
+            <li>Aguarde a aprovação de um administrador.</li>
+          </ol>
         </Box>
       )}
     </Box>

--- a/app/(pages)/(private)/update-profile/action.ts
+++ b/app/(pages)/(private)/update-profile/action.ts
@@ -5,30 +5,42 @@ import { lambda } from '@/services/lambda';
 import { createUpdatePendingDataUseCase } from '@/useCases/updatePendingDataUseCase';
 import { revalidatePath } from 'next/cache';
 
-export async function tryToUpdateUserPendingDataAction(
+type EditUserRegisterFormProps = {
+  pendingDataId?: string;
+  userId: string;
+  cpf: string;
+  cep: string;
+  address: string;
+  number: string;
+  complement: string;
+  course: string;
+  photoUrl: string;
+  photo?: File;
+};
+
+export async function editUserRegisterFormAction(
   _state: unknown,
   formData: FormData,
+) {
+  const editRegisterInput = Object.fromEntries(
+    formData.entries(),
+  ) as EditUserRegisterFormProps;
+
+  if (editRegisterInput.pendingDataId) {
+    return await updateRejectedPendingDataAction(editRegisterInput);
+  }
+
+  return await forgotPrivateKeyAction(editRegisterInput);
+}
+
+async function updateRejectedPendingDataAction(
+  input: EditUserRegisterFormProps,
 ) {
   const userRepository = createUserRepository();
   const { updatePendingDataUseCase } =
     createUpdatePendingDataUseCase(userRepository);
 
-  type FormData = {
-    pendingDataId: string;
-    userId: string;
-    cpf: string;
-    cep: string;
-    address: string;
-    number: string;
-    complement: string;
-    course: string;
-    photoUrl: string;
-    photo?: File;
-  };
-
-  const { userId, pendingDataId, ...data } = Object.fromEntries(
-    formData.entries(),
-  ) as FormData;
+  const { userId, pendingDataId, ...data } = input;
 
   const dataToUpdate = {
     cpf: data.cpf,
@@ -46,7 +58,7 @@ export async function tryToUpdateUserPendingDataAction(
   }
 
   const response = await updatePendingDataUseCase({
-    id: pendingDataId,
+    id: pendingDataId!,
     dataToUpdate,
   });
 
@@ -57,4 +69,15 @@ export async function tryToUpdateUserPendingDataAction(
   revalidatePath('/update-profile');
 
   return response;
+}
+
+async function forgotPrivateKeyAction(input: EditUserRegisterFormProps) {
+  console.log(input);
+
+  return {
+    errors: null,
+    data: {
+      message: 'Alguma coisa',
+    },
+  };
 }

--- a/app/(pages)/(private)/update-profile/components/EditUserRegisterForm.tsx
+++ b/app/(pages)/(private)/update-profile/components/EditUserRegisterForm.tsx
@@ -4,18 +4,25 @@ import { CustomInput } from '@/app/components/CustomInput';
 import { CustomSelect } from '@/app/components/CustomSelect';
 import { LoadingButton } from '@/app/components/LoadingButton';
 import { Avatar, Text } from '@primer/react';
-import { UserPendingData } from '@prisma/client';
+import { UserPendingData, UserStatus } from '@prisma/client';
 import { useFormState } from 'react-dom';
-import { tryToUpdateUserPendingDataAction } from '../action';
+import { editUserRegisterFormAction } from '../action';
 
 type EditUserRegisterFormProps = {
   userPendingData: UserPendingData | null;
+  user: {
+    id: string;
+    name: string;
+    email: string;
+    status: UserStatus;
+  };
 };
 
 export function EditUserRegisterForm({
   userPendingData,
+  user,
 }: EditUserRegisterFormProps) {
-  const [state, action] = useFormState(tryToUpdateUserPendingDataAction, null);
+  const [state, action] = useFormState(editUserRegisterFormAction, null);
 
   function getErrorMessage(path: string) {
     return state?.errors?.find((error) => error.path.includes(path))?.message;
@@ -47,25 +54,25 @@ export function EditUserRegisterForm({
           mb: 2,
         }}
       >
-        Sobre o aluno: {userPendingData?.name}
+        Sobre o aluno: {userPendingData?.name ?? user.name}
         <br />
-        email: {userPendingData?.email}
+        email: {userPendingData?.email ?? user.email}
       </Text>
 
       <input
         name="pendingDataId"
         type="hidden"
-        defaultValue={userPendingData!.id}
+        defaultValue={userPendingData?.id}
       />
       <input
         name="userId"
         type="hidden"
-        defaultValue={userPendingData!.userId}
+        defaultValue={userPendingData?.userId ?? user.id}
       />
       <input
         name="photoUrl"
         type="hidden"
-        defaultValue={userPendingData!.photoUrl}
+        defaultValue={userPendingData?.photoUrl}
       />
 
       <CustomInput

--- a/app/(pages)/(private)/update-profile/page.tsx
+++ b/app/(pages)/(private)/update-profile/page.tsx
@@ -1,15 +1,18 @@
 import { createUserRepository } from '@/repositories/userRepository';
 import { identity } from '@/utils/idendity';
 import { Box } from '@primer/react';
+import { UserStatus } from '@prisma/client';
 import { redirect, RedirectType } from 'next/navigation';
 import { EditUserRegisterForm } from './components/EditUserRegisterForm';
 
 export default async function Page() {
   const signedUser = await identity.isLoggedIn();
+  const acceptedUserStatus: UserStatus[] = ['FORGOT_PK', 'REJECTED'];
+
   if (
     !signedUser ||
-    signedUser.status !== 'REJECTED' ||
-    signedUser.role == 'ADMIN'
+    !acceptedUserStatus.includes(signedUser.status) ||
+    signedUser.role === 'ADMIN'
   ) {
     return redirect('/', RedirectType.replace);
   }
@@ -30,7 +33,15 @@ export default async function Page() {
         overflowY: 'auto',
       }}
     >
-      <EditUserRegisterForm userPendingData={userPendingData} />
+      <EditUserRegisterForm
+        userPendingData={userPendingData}
+        user={{
+          id: signedUser.id,
+          name: signedUser.name,
+          email: signedUser.email,
+          status: signedUser.status,
+        }}
+      />
     </Box>
   );
 }

--- a/app/ui/Sidebar.tsx
+++ b/app/ui/Sidebar.tsx
@@ -6,7 +6,8 @@ import { NavListItem } from '../components/NavListItem';
 export async function Sidebar() {
   const userSignedIn = await identity.isLoggedIn();
   const isUserAdmin = userSignedIn && userSignedIn.role === 'ADMIN';
-  const isUserRejected = userSignedIn && userSignedIn.status === 'REJECTED';
+  const userCanUpdateProfile =
+    userSignedIn && ['FORGOT_PK', 'REJECTED'].includes(userSignedIn.status);
 
   return (
     <Box
@@ -34,7 +35,8 @@ export async function Sidebar() {
           if (userSignedIn && item.auth.onlyNotSignedIn) return null;
           if (!isUserAdmin && item.auth.onlyAdmin) return null;
           if (isUserAdmin && item.auth.onlyStudent) return null;
-          if (!isUserRejected && item.href === '/update-profile') return null;
+          if (!userCanUpdateProfile && item.href === '/update-profile')
+            return null;
 
           return <NavListItem key={item.href} item={item} />;
         })}

--- a/prisma/migrations/20241010214447_adds_forgot_pk_status_enum/migration.sql
+++ b/prisma/migrations/20241010214447_adds_forgot_pk_status_enum/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "user_status" ADD VALUE 'FORGOT_PK';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -11,6 +11,7 @@ enum UserStatus {
   PENDING
   APPROVED
   REJECTED
+  FORGOT_PK
 
   @@map("user_status")
 }


### PR DESCRIPTION
## Preview
[Gravação de tela de 10-10-2024 23:06:45.webm](https://github.com/user-attachments/assets/a398d26a-dcf4-4718-ab21-b0c41e4754e2)

## TODO
It's not implemented the full functionality yet. I have to create a function that:
- save the `user pending data` (filled in `/update-profile` page)
- generate new cryptographic keyPairs and update it in `Users` table
- show the new private key to the user
- update userStatus to `pending`