### PR TITLE
Creates `forgotPrivateKeyUseCase` and integrates it with `/update-profile` page

### DIFF
--- a/app/(pages)/(private)/update-profile/components/EditUserRegisterForm.tsx
+++ b/app/(pages)/(private)/update-profile/components/EditUserRegisterForm.tsx
@@ -2,9 +2,10 @@
 
 import { CustomInput } from '@/app/components/CustomInput';
 import { CustomSelect } from '@/app/components/CustomSelect';
+import { Instructions } from '@/app/components/Instructions';
 import { LoadingButton } from '@/app/components/LoadingButton';
 import { Avatar, Text } from '@primer/react';
-import { UserPendingData, UserStatus } from '@prisma/client';
+import { UserPendingData } from '@prisma/client';
 import { useFormState } from 'react-dom';
 import { editUserRegisterFormAction } from '../action';
 
@@ -14,7 +15,7 @@ type EditUserRegisterFormProps = {
     id: string;
     name: string;
     email: string;
-    status: UserStatus;
+    status: 'FORGOT_PK' | 'REJECTED';
   };
 };
 
@@ -28,132 +29,167 @@ export function EditUserRegisterForm({
     return state?.errors?.find((error) => error.path.includes(path))?.message;
   }
 
-  return (
-    <form
-      action={action}
-      style={{
-        display: 'flex',
-        flexDirection: 'column',
-        gap: 2,
-        maxWidth: 400,
-        width: '100%',
-      }}
-    >
-      {userPendingData?.photoUrl && (
-        <Avatar
-          sx={{
-            width: 50,
-            height: 50,
-          }}
-          src={userPendingData.photoUrl}
-          alt="Foto do aluno"
-        />
-      )}
-      <Text
-        sx={{
-          mb: 2,
+  if (state?.data?.privateKey) {
+    return (
+      <Instructions
+        data={{
+          message: state.data.message,
+          privateKey: state.data.privateKey,
         }}
-      >
-        Sobre o aluno: {userPendingData?.name ?? user.name}
-        <br />
-        email: {userPendingData?.email ?? user.email}
+        type="forgotPrivateKey"
+      />
+    );
+  }
+
+  return (
+    <>
+      <Text as="h2">
+        {user.status === 'FORGOT_PK'
+          ? 'Preencha o formulário para realizar o processo de criação de uma nova carteira'
+          : 'Preencha o formulário para atualizar seus dados e solicitar a matrícula novamente'}
       </Text>
 
-      <input
-        name="pendingDataId"
-        type="hidden"
-        defaultValue={userPendingData?.id}
-      />
-      <input
-        name="userId"
-        type="hidden"
-        defaultValue={userPendingData?.userId ?? user.id}
-      />
-      <input
-        name="photoUrl"
-        type="hidden"
-        defaultValue={userPendingData?.photoUrl}
-      />
-
-      <CustomInput
-        label="CPF"
-        name="cpf"
-        type="number"
-        required
-        defaultValue={userPendingData?.cpf}
-        error={getErrorMessage('cpf')}
-      />
-      <CustomInput
-        label="Cep"
-        name="cep"
-        type="number"
-        required
-        defaultValue={userPendingData?.cep}
-        error={getErrorMessage('cep')}
-      />
-      <CustomInput
-        label="Endereço"
-        name="address"
-        required
-        defaultValue={userPendingData?.address}
-        error={getErrorMessage('address')}
-      />
-      <CustomInput
-        label="Número"
-        name="number"
-        type="number"
-        required
-        defaultValue={userPendingData?.number}
-        error={getErrorMessage('number')}
-      />
-      <CustomInput
-        label="Complemento"
-        name="complement"
-        defaultValue={userPendingData?.complement ?? ''}
-        error={getErrorMessage('complement')}
-      />
-
-      <label
-        htmlFor="course"
-        style={{ fontWeight: 'bold', cursor: 'pointer', fontSize: 14 }}
+      <form
+        action={action}
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 2,
+          maxWidth: 400,
+          width: '100%',
+        }}
       >
-        Curso desejado
-      </label>
-      <CustomSelect
-        id="course"
-        name="course"
-        required
-        defaultValue={userPendingData?.course}
-        options={[
-          { value: '', label: '' },
-          { value: 'ciencia-da-computacao', label: 'Ciência da Computação' },
-          {
-            value: 'engenharia-de-software',
-            label: 'Engenharia de Software',
-          },
-          {
-            value: 'sistemas-de-informacao',
-            label: 'Sistemas de Informação',
-          },
-        ]}
-      />
+        {userPendingData?.photoUrl && (
+          <Avatar
+            sx={{
+              width: 50,
+              height: 50,
+            }}
+            src={userPendingData.photoUrl}
+            alt="Foto do aluno"
+          />
+        )}
+        <Text
+          sx={{
+            mb: 2,
+          }}
+        >
+          Sobre o aluno: {userPendingData?.name ?? user.name}
+          <br />
+          email: {userPendingData?.email ?? user.email}
+        </Text>
 
-      <label
-        htmlFor="photo"
-        style={{ fontWeight: 'bold', cursor: 'pointer', fontSize: 14 }}
-      >
-        Foto do aluno
-      </label>
-      <input
-        type="file"
-        name="photo"
-        id="photo"
-        accept="image/png, image/jpg, image/jpeg"
-      />
+        <input name="name" type="hidden" defaultValue={user.name} />
+        <input name="email" type="hidden" defaultValue={user.email} />
 
-      <LoadingButton>
-        Atualizar dados e solicitar matrícula novamente
-      </LoadingButton>
-    </form>
+        <input
+          name="pendingDataId"
+          type="hidden"
+          defaultValue={userPendingData?.id}
+        />
+
+        <input
+          name="userId"
+          type="hidden"
+          defaultValue={userPendingData?.userId ?? user.id}
+        />
+        <input
+          name="photoUrl"
+          type="hidden"
+          defaultValue={userPendingData?.photoUrl}
+        />
+
+        {user.status == 'FORGOT_PK' && (
+          <CustomInput
+            label="Senha"
+            name="password"
+            type="password"
+            required
+            error={getErrorMessage('password')}
+          />
+        )}
+
+        <CustomInput
+          label="CPF"
+          name="cpf"
+          type="number"
+          required
+          defaultValue={userPendingData?.cpf}
+          error={getErrorMessage('cpf')}
+        />
+        <CustomInput
+          label="Cep"
+          name="cep"
+          type="number"
+          required
+          defaultValue={userPendingData?.cep}
+          error={getErrorMessage('cep')}
+        />
+        <CustomInput
+          label="Endereço"
+          name="address"
+          required
+          defaultValue={userPendingData?.address}
+          error={getErrorMessage('address')}
+        />
+        <CustomInput
+          label="Número"
+          name="number"
+          type="number"
+          required
+          defaultValue={userPendingData?.number}
+          error={getErrorMessage('number')}
+        />
+        <CustomInput
+          label="Complemento"
+          name="complement"
+          defaultValue={userPendingData?.complement ?? ''}
+          error={getErrorMessage('complement')}
+        />
+
+        <label
+          htmlFor="course"
+          style={{ fontWeight: 'bold', cursor: 'pointer', fontSize: 14 }}
+        >
+          Curso desejado
+        </label>
+        <CustomSelect
+          id="course"
+          name="course"
+          required
+          defaultValue={userPendingData?.course}
+          options={[
+            { value: '', label: '' },
+            { value: 'ciencia-da-computacao', label: 'Ciência da Computação' },
+            {
+              value: 'engenharia-de-software',
+              label: 'Engenharia de Software',
+            },
+            {
+              value: 'sistemas-de-informacao',
+              label: 'Sistemas de Informação',
+            },
+          ]}
+        />
+
+        <label
+          htmlFor="photo"
+          style={{ fontWeight: 'bold', cursor: 'pointer', fontSize: 14 }}
+        >
+          Foto do aluno
+        </label>
+        <input
+          required={user.status === 'FORGOT_PK'}
+          type="file"
+          name="photo"
+          id="photo"
+          accept="image/png, image/jpg, image/jpeg"
+        />
+
+        <LoadingButton>
+          Atualizar dados e solicitar matrícula novamente
+        </LoadingButton>
+      </form>
+    </>
   );
 }

--- a/app/(pages)/(private)/update-profile/page.tsx
+++ b/app/(pages)/(private)/update-profile/page.tsx
@@ -39,7 +39,7 @@ export default async function Page() {
           id: signedUser.id,
           name: signedUser.name,
           email: signedUser.email,
-          status: signedUser.status,
+          status: signedUser.status as 'FORGOT_PK' | 'REJECTED',
         }}
       />
     </Box>

--- a/app/(pages)/register/components/RegisterForm.tsx
+++ b/app/(pages)/register/components/RegisterForm.tsx
@@ -6,7 +6,7 @@ import { CustomSelect } from '@/app/components/CustomSelect';
 import { LoadingButton } from '@/app/components/LoadingButton';
 import { Box, Text } from '@primer/react';
 import { useFormState } from 'react-dom';
-import { Instructions } from './Instructions';
+import { Instructions } from '../../../components/Instructions';
 
 export function RegisterForm() {
   const [state, action] = useFormState(tryToRegisterUserAction, null);
@@ -16,7 +16,7 @@ export function RegisterForm() {
   }
 
   if (state?.data) {
-    return <Instructions data={state.data} />;
+    return <Instructions data={state.data} type="register" />;
   }
 
   return (

--- a/app/components/Instructions.tsx
+++ b/app/components/Instructions.tsx
@@ -10,9 +10,10 @@ type InstructionsProps = {
     message: string;
     privateKey: string;
   };
+  type: 'register' | 'forgotPrivateKey';
 };
 
-export function Instructions({ data }: InstructionsProps) {
+export function Instructions({ data, type }: InstructionsProps) {
   const [isCopied, setIsCopied] = useState(false);
   const route = useRouter();
 
@@ -41,21 +42,39 @@ export function Instructions({ data }: InstructionsProps) {
         Copiar chave privada
       </CopyToClipBoard>
 
-      <Button
-        onClick={() => {
-          route.replace('/login');
-          route.refresh();
-        }}
-        disabled={!isCopied}
-        variant="primary"
-        sx={{
-          mt: 4,
-          display: 'flex',
-          width: '100%',
-        }}
-      >
-        Logar na conta
-      </Button>
+      {type === 'register' ? (
+        <Button
+          onClick={() => {
+            route.replace('/login');
+            route.refresh();
+          }}
+          disabled={!isCopied}
+          variant="primary"
+          sx={{
+            mt: 4,
+            display: 'flex',
+            width: '100%',
+          }}
+        >
+          Logar na conta
+        </Button>
+      ) : (
+        <Button
+          onClick={() => {
+            route.replace('/student-card/status');
+            route.refresh();
+          }}
+          disabled={!isCopied}
+          variant="primary"
+          sx={{
+            mt: 4,
+            display: 'flex',
+            width: '100%',
+          }}
+        >
+          Ver status da solicitação
+        </Button>
+      )}
     </Flash>
   );
 }

--- a/repositories/userRepository.ts
+++ b/repositories/userRepository.ts
@@ -1,5 +1,5 @@
 import prismaClient from '@/lib/prismaClient';
-import { User, UserStatus } from '@prisma/client';
+import { UserStatus } from '@prisma/client';
 
 type CreateUserInput = {
   name: string;
@@ -15,7 +15,7 @@ type CreateUserOutput = {
   email: string;
 };
 
-type CreatePendingDataInput = {
+export type CreatePendingDataInput = {
   name: string;
   email: string;
   cpf: string;
@@ -41,6 +41,12 @@ export type UpdatePendingDataInput = {
   };
 };
 
+type UpdatePublicKeysInput = {
+  userId: string;
+  publicKey: string;
+  ethAddress: string;
+};
+
 export type UserRepository = ReturnType<typeof createUserRepository>;
 
 export function createUserRepository() {
@@ -52,6 +58,7 @@ export function createUserRepository() {
     findPendingUsers,
     deletePendingData,
     updateStatus,
+    updatePublicKeys,
     updatePendingData,
     findPendingDataByUserId,
   });
@@ -59,7 +66,10 @@ export function createUserRepository() {
     withPassword?: boolean;
   };
 
-  async function findById(id: string): Promise<Omit<User, 'password'> | null> {
+  async function findById(
+    id: string,
+    { withPassword = false }: WithPassword = {},
+  ) {
     return await prismaClient.user.findUnique({
       where: {
         id,
@@ -73,6 +83,7 @@ export function createUserRepository() {
         status: true,
         createdAt: true,
         role: true,
+        password: withPassword,
       },
     });
   }
@@ -121,6 +132,22 @@ export function createUserRepository() {
       },
       data: {
         status,
+      },
+    });
+  }
+
+  async function updatePublicKeys({
+    userId,
+    ethAddress,
+    publicKey,
+  }: UpdatePublicKeysInput) {
+    await prismaClient.user.update({
+      where: {
+        id: userId,
+      },
+      data: {
+        ethAddress,
+        publicKey,
       },
     });
   }

--- a/tests/useCases/forgotPrivateKeyUseCase.test.ts
+++ b/tests/useCases/forgotPrivateKeyUseCase.test.ts
@@ -1,0 +1,371 @@
+import { createUserRepository } from '@/repositories/userRepository';
+import { cryptography } from '@/services/cryptography';
+import { LambdaService } from '@/services/lambda';
+import { forgotPrivateKeyUseCase } from '@/useCases/forgotPrivateKeyUseCase';
+import bcrypt from 'bcryptjs';
+import { randomBytes, randomUUID } from 'crypto';
+
+describe('> Forgot Private Key Use Case', () => {
+  const userRepository = createUserRepository();
+  const lambdaService: LambdaService = {
+    uploadFile: async (_file: File) => {
+      return {
+        file_url: '',
+      };
+    },
+  };
+
+  const defaultPassword = '123456';
+  const SALT_ROUNDS = 2;
+  const defaultHashedPassword = bcrypt.hashSync(defaultPassword, SALT_ROUNDS);
+
+  it('should return an error when at least one "newData" property is undefined', async () => {
+    const email = randomBytes(8).toString('hex') + '@mail.com';
+    const name = randomBytes(8).toString('hex');
+
+    const createdUser = await userRepository.create({
+      email,
+      name,
+      publicKey: randomUUID(),
+      ethAddress: randomUUID(),
+      passwordHash: defaultHashedPassword,
+    });
+
+    const result = await forgotPrivateKeyUseCase(
+      userRepository,
+      lambdaService,
+      cryptography,
+      {
+        userId: createdUser.id,
+        password: defaultPassword,
+        newData: {
+          address: undefined as unknown as string,
+          cep: '12345678',
+          course: 'ciencia-da-computacao',
+          cpf: '12345678901',
+          number: '123',
+          complement: 'Test complement',
+          email,
+          name,
+          photo: new File([''], 'test.jpg'),
+        },
+      },
+    );
+
+    expect(result).toStrictEqual({
+      data: null,
+      errors: [
+        {
+          path: ['address'],
+          message: 'O campo endereço é obrigatório',
+          received: 'undefined',
+          expected: 'string',
+          code: 'invalid_type',
+        },
+      ],
+    });
+  });
+
+  it('should return an error when at least one "newData" property is invalid type', async () => {
+    const email = randomBytes(8).toString('hex') + '@mail.com';
+    const name = randomBytes(8).toString('hex');
+
+    const createdUser = await userRepository.create({
+      email,
+      name,
+      publicKey: randomUUID(),
+      ethAddress: randomUUID(),
+      passwordHash: defaultHashedPassword,
+    });
+
+    const result = await forgotPrivateKeyUseCase(
+      userRepository,
+      lambdaService,
+      cryptography,
+      {
+        userId: createdUser.id,
+        password: defaultPassword,
+        newData: {
+          address: 1 as unknown as string,
+          cep: '12345678',
+          course: 'ciencia-da-computacao',
+          cpf: '12345678901',
+          number: '123',
+          complement: 'Test complement',
+          email,
+          name,
+          photo: new File([''], 'test.jpg'),
+        },
+      },
+    );
+
+    expect(result).toStrictEqual({
+      data: null,
+      errors: [
+        {
+          path: ['address'],
+          message: 'O campo endereço deve ser uma string',
+          received: 'number',
+          expected: 'string',
+          code: 'invalid_type',
+        },
+      ],
+    });
+  });
+
+  it('should return an error when userStatus is not "FORGOT_PK"', async () => {
+    const email = randomBytes(8).toString('hex') + '@mail.com';
+    const name = randomBytes(8).toString('hex');
+
+    // user default status is "PENDING"
+    const createdUser = await userRepository.create({
+      email,
+      name,
+      publicKey: randomUUID(),
+      ethAddress: randomUUID(),
+      passwordHash: defaultHashedPassword,
+    });
+
+    const result = await forgotPrivateKeyUseCase(
+      userRepository,
+      lambdaService,
+      cryptography,
+      {
+        userId: createdUser.id,
+        password: defaultPassword,
+        newData: {
+          address: 'Test address',
+          cep: '12345678',
+          course: 'ciencia-da-computacao',
+          cpf: '12345678901',
+          number: '123',
+          complement: 'Test complement',
+          email,
+          name,
+          photo: new File([''], 'test.jpg'),
+        },
+      },
+    );
+
+    expect(result).toStrictEqual({
+      data: null,
+      errors: [
+        {
+          path: ['userStatus'],
+          message: 'A ação não é válida para o status atual do usuário.',
+        },
+      ],
+    });
+  });
+
+  it('should return an error when userId does not exists', async () => {
+    const email = randomBytes(8).toString('hex') + '@mail.com';
+    const name = randomBytes(8).toString('hex');
+
+    const result = await forgotPrivateKeyUseCase(
+      userRepository,
+      lambdaService,
+      cryptography,
+      {
+        userId: randomUUID(),
+        password: defaultPassword,
+        newData: {
+          address: 'Test address',
+          cep: '12345678',
+          course: 'ciencia-da-computacao',
+          cpf: '12345678901',
+          number: '123',
+          complement: 'Test complement',
+          email,
+          name,
+          photo: new File([''], 'test.jpg'),
+        },
+      },
+    );
+
+    expect(result).toStrictEqual({
+      data: null,
+      errors: [
+        {
+          path: ['userId'],
+          message: 'Usuário não encontrado',
+        },
+      ],
+    });
+  });
+
+  it('should return an error when password is invalid', async () => {
+    const email = randomBytes(8).toString('hex') + '@mail.com';
+    const name = randomBytes(8).toString('hex');
+
+    const createdUser = await userRepository.create({
+      email,
+      name,
+      publicKey: randomUUID(),
+      ethAddress: randomUUID(),
+      passwordHash: defaultHashedPassword,
+    });
+
+    await userRepository.updateStatus(createdUser.id, 'FORGOT_PK');
+
+    const result = await forgotPrivateKeyUseCase(
+      userRepository,
+      lambdaService,
+      cryptography,
+      {
+        userId: createdUser.id,
+        password: 'invalidPassword',
+        newData: {
+          address: 'Test address',
+          cep: '12345678',
+          course: 'ciencia-da-computacao',
+          cpf: '12345678901',
+          number: '123',
+          complement: 'Test complement',
+          email,
+          name,
+          photo: new File([''], 'test.jpg'),
+        },
+      },
+    );
+
+    expect(result).toStrictEqual({
+      data: null,
+      errors: [
+        {
+          path: ['password'],
+          message: 'Senha inválida',
+        },
+      ],
+    });
+  });
+
+  it('should return an error when user already has a pending data', async () => {
+    const email = randomBytes(8).toString('hex') + '@mail.com';
+    const name = randomBytes(8).toString('hex');
+
+    const createdUser = await userRepository.create({
+      email,
+      name,
+      publicKey: randomUUID(),
+      ethAddress: randomUUID(),
+      passwordHash: defaultHashedPassword,
+    });
+
+    await userRepository.updateStatus(createdUser.id, 'FORGOT_PK');
+
+    const pendinDataInput = {
+      address: 'Test address',
+      cep: '12345678',
+      course: 'ciencia-da-computacao',
+      cpf: '12345678901',
+      number: '123',
+      complement: 'Test complement',
+      email,
+      name,
+    };
+
+    await userRepository.createPendingData(createdUser.id, {
+      ...pendinDataInput,
+      photoUrl: 'http://test.com/photo.jpg',
+    });
+
+    const result = await forgotPrivateKeyUseCase(
+      userRepository,
+      lambdaService,
+      cryptography,
+      {
+        userId: createdUser.id,
+        password: defaultPassword,
+        newData: {
+          ...pendinDataInput,
+          photo: new File([''], 'test.jpg'),
+        },
+      },
+    );
+
+    expect(result).toStrictEqual({
+      data: null,
+      errors: [
+        {
+          path: ['userId'],
+          message: 'Já existe uma solicitação pendente para este usuário.',
+        },
+      ],
+    });
+  });
+
+  it('should return a success message and new privateKey when all data is valid', async () => {
+    const email = randomBytes(8).toString('hex') + '@mail.com';
+    const name = randomBytes(8).toString('hex');
+
+    const createdUser = await userRepository.create({
+      email,
+      name,
+      publicKey: randomUUID(),
+      ethAddress: randomUUID(),
+      passwordHash: defaultHashedPassword,
+    });
+
+    await userRepository.updateStatus(createdUser.id, 'FORGOT_PK');
+
+    const pendingDataInput = {
+      address: 'Test address',
+      cep: '12345678',
+      course: 'ciencia-da-computacao',
+      cpf: '12345678901',
+      number: '123',
+      complement: 'Test complement',
+      email,
+      name,
+      photo: new File([''], 'test.jpg'),
+    };
+
+    const userBeforeUpdate = await userRepository.findById(createdUser.id);
+
+    const result = await forgotPrivateKeyUseCase(
+      userRepository,
+      lambdaService,
+      cryptography,
+      {
+        userId: createdUser.id,
+        password: defaultPassword,
+        newData: pendingDataInput,
+      },
+    );
+
+    const userAfterUpdate = await userRepository.findById(createdUser.id);
+
+    expect(userBeforeUpdate!.publicKey).not.equal(userAfterUpdate!.publicKey);
+    expect(userBeforeUpdate!.ethAddress).not.equal(userAfterUpdate!.ethAddress);
+
+    const pendingDataFound = await userRepository.findPendingDataByUserId(
+      createdUser.id,
+    );
+    expect(pendingDataFound).toStrictEqual({
+      id: expect.any(String),
+      userId: expect.any(String),
+      name,
+      email,
+      cpf: pendingDataInput.cpf,
+      cep: pendingDataInput.cep,
+      address: pendingDataInput.address,
+      number: pendingDataInput.number,
+      registration: expect.any(Number),
+      complement: pendingDataInput.complement,
+      course: pendingDataInput.course,
+      photoUrl: '',
+      rejection_reason: null,
+      createdAt: expect.any(Date),
+    });
+
+    expect(result).toStrictEqual({
+      errors: null,
+      data: {
+        message:
+          'Solicitação de recuperação de chave privada realizada com sucesso. Aguarde a aprovação.',
+        privateKey: expect.any(String),
+      },
+    });
+  });
+});

--- a/tests/useCases/updatePendingDataUseCase.test.ts
+++ b/tests/useCases/updatePendingDataUseCase.test.ts
@@ -8,7 +8,7 @@ beforeAll(async () => {
 });
 
 describe('> Update Pending Data Use Case', () => {
-  it('should return a error when send at lead one invalid input field', async () => {
+  it('should return a error when send at least one invalid input field', async () => {
     const userRepository = createUserRepository();
     const { updatePendingDataUseCase } =
       createUpdatePendingDataUseCase(userRepository);

--- a/useCases/forgotPrivateKeyUseCase.ts
+++ b/useCases/forgotPrivateKeyUseCase.ts
@@ -1,0 +1,183 @@
+import {
+  CreatePendingDataInput,
+  UserRepository,
+} from '@/repositories/userRepository';
+import { CryptographyService } from '@/services/cryptography';
+import { LambdaService } from '@/services/lambda';
+import bcrypt from 'bcryptjs';
+import { z, ZodIssue } from 'zod';
+
+type PendingDataProps = Omit<CreatePendingDataInput, 'photoUrl'> & {
+  photo: File;
+};
+
+type ForgotPrivateKeyProps = {
+  newData: PendingDataProps;
+  userId: string;
+  password: string;
+};
+
+export async function forgotPrivateKeyUseCase(
+  userRepository: UserRepository,
+  lambdaService: LambdaService,
+  cryptographyService: CryptographyService,
+  input: ForgotPrivateKeyProps,
+) {
+  const validationResult = schema.safeParse(input.newData);
+  if (validationResult.error) {
+    return {
+      errors: validationResult.error.issues,
+      data: null,
+    };
+  }
+
+  const userFound = await userRepository.findById(input.userId, {
+    withPassword: true,
+  });
+  if (!userFound) {
+    return {
+      data: null,
+      errors: [
+        {
+          path: ['userId'],
+          message: 'Usuário não encontrado',
+        },
+      ] as ZodIssue[],
+    };
+  }
+
+  if (userFound.status !== 'FORGOT_PK') {
+    return {
+      data: null,
+      errors: [
+        {
+          path: ['userStatus'],
+          message: 'A ação não é válida para o status atual do usuário.',
+        },
+      ] as ZodIssue[],
+    };
+  }
+
+  const isPasswordValid = bcrypt.compareSync(
+    input.password,
+    userFound.password,
+  );
+
+  if (!isPasswordValid) {
+    return {
+      data: null,
+      errors: [
+        {
+          path: ['password'],
+          message: 'Senha inválida',
+        },
+      ] as ZodIssue[],
+    };
+  }
+
+  const foundPendingData = await userRepository.findPendingDataByUserId(
+    input.userId,
+  );
+  if (foundPendingData) {
+    return {
+      data: null,
+      errors: [
+        {
+          path: ['userId'],
+          message: 'Já existe uma solicitação pendente para este usuário.',
+        },
+      ] as ZodIssue[],
+    };
+  }
+
+  const { photo, ...data } = input.newData;
+  const { file_url } = await lambdaService.uploadFile(photo);
+
+  await userRepository.createPendingData(input.userId, {
+    ...data,
+    photoUrl: file_url,
+  });
+
+  const { privateKey, publicKey } = cryptographyService.generateKeyPairs({
+    passphrase: input.password,
+  });
+  const userEthAddress = cryptographyService.generateEthAddress(publicKey);
+
+  await userRepository.updatePublicKeys({
+    userId: input.userId,
+    ethAddress: userEthAddress,
+    publicKey,
+  });
+  await userRepository.updateStatus(input.userId, 'PENDING');
+
+  return {
+    errors: null,
+    data: {
+      message:
+        'Solicitação de recuperação de chave privada realizada com sucesso. Aguarde a aprovação.',
+      privateKey,
+    },
+  };
+}
+
+const schema = z.object({
+  cpf: z
+    .string({
+      invalid_type_error: 'O campo cpf deve ser uma string',
+      required_error: 'O campo cpf é obrigatório',
+    })
+    .length(11, {
+      message: 'O campo cpf deve ter 11 caracteres',
+    })
+    .regex(/^\d+$/, {
+      message: 'O campo cpf deve conter apenas números',
+    }),
+  cep: z
+    .string({
+      invalid_type_error: 'O campo cep deve ser uma string',
+      required_error: 'O campo cep é obrigatório',
+    })
+    .length(8, {
+      message: 'O campo cep deve ter 8 caracteres',
+    })
+    .regex(/^\d+$/, {
+      message: 'O campo cep deve conter apenas números',
+    }),
+  address: z
+    .string({
+      invalid_type_error: 'O campo endereço deve ser uma string',
+      required_error: 'O campo endereço é obrigatório',
+    })
+    .min(3, {
+      message: 'O campo endereço deve ter no mínimo 3 caracteres',
+    }),
+  number: z
+    .string({
+      invalid_type_error: 'O campo número deve ser uma string',
+      required_error: 'O campo número é obrigatório',
+    })
+    .regex(/^\d+$/, {
+      message: 'O campo número deve conter apenas números',
+    }),
+  complement: z
+    .string({
+      invalid_type_error: 'O campo complemento deve ser uma string',
+    })
+    .optional(),
+  course: z
+    .string({
+      invalid_type_error: 'O campo curso deve ser uma string',
+      required_error: 'O campo curso é obrigatório',
+    })
+    .refine(
+      (value) =>
+        [
+          'ciencia-da-computacao',
+          'engenharia-de-software',
+          'sistemas-de-informacao',
+        ].includes(value),
+      {
+        message: 'O campo curso deve ser uma das opções disponíveis',
+      },
+    ),
+});


### PR DESCRIPTION
## Preview
[Gravação de tela de 11-10-2024 21:35:21.webm](https://github.com/user-attachments/assets/362830f9-b788-4143-a3a1-a4f3c1ff3a17)

## Done
- Created `forgotPrivateKeyUseCase` with all validations and depencency injection (to simplify tests with mock)
- Creted tests for all use cases of `forgotPrivateKeyUseCase` method
- Refactored `Instructions` component to be used in  both `forgot_pk` or `rejected` userStatus context
- Integrated `forgotPrivateKeyUseCase` with `server action` in `/update-profile` page

## Results
With this PR, even if the user (student) lose his private key he will be able to create a new one without creating a new account.
- The steps to do this is:
  - invalidate current user card on blockchain (it's possible using his publicKey, that is saved in database)
  - update userStatus to `forgot_pk`
  - user fill-up the form with necessary information to create a new card
  - save this information in `user_pending_data` table again (to be approved or not by admin. And if approved it will be emitted to blockchain and deleted from database)
  - new public/private keyPairs are created to the user, replacing the old publicKeys in database
  - update userStatus to `pending`
  - show new privateKey to the user