### PR TITLE
Refactor the authentication/authorization flow

### DIFF
--- a/app/(pages)/(private)/(admin)/issued-cards/layout.tsx
+++ b/app/(pages)/(private)/(admin)/issued-cards/layout.tsx
@@ -1,0 +1,15 @@
+import { identity } from '@/utils/idendity';
+import { redirect, RedirectType } from 'next/navigation';
+import { ReactNode } from 'react';
+
+type Props = {
+  children: ReactNode;
+};
+export default async function Layout({ children }: Props) {
+  const signedUser = await identity.isLoggedIn();
+  if (!signedUser || signedUser.role !== 'ADMIN') {
+    return redirect('/', RedirectType.replace);
+  }
+
+  return children;
+}

--- a/app/(pages)/(private)/(admin)/issued-cards/layout.tsx
+++ b/app/(pages)/(private)/(admin)/issued-cards/layout.tsx
@@ -6,7 +6,7 @@ type Props = {
   children: ReactNode;
 };
 export default async function Layout({ children }: Props) {
-  const signedUser = await identity.isLoggedIn();
+  const signedUser = await identity.getMe();
   if (!signedUser || signedUser.role !== 'ADMIN') {
     return redirect('/', RedirectType.replace);
   }

--- a/app/(pages)/(private)/(admin)/pending-cards/page.tsx
+++ b/app/(pages)/(private)/(admin)/pending-cards/page.tsx
@@ -5,7 +5,7 @@ import { redirect, RedirectType } from 'next/navigation';
 import { PendingTable } from './components/PendingTable';
 
 export default async function Page() {
-  const signedUser = await identity.isLoggedIn();
+  const signedUser = await identity.getMe();
   if (!signedUser || signedUser.role !== 'ADMIN') {
     return redirect('/', RedirectType.replace);
   }

--- a/app/(pages)/(private)/student-card/page.tsx
+++ b/app/(pages)/(private)/student-card/page.tsx
@@ -6,7 +6,7 @@ import { redirect, RedirectType } from 'next/navigation';
 import { StudentCard } from './components/StudentCard';
 
 export default async function Page() {
-  const signedUser = await identity.isLoggedIn();
+  const signedUser = await identity.getMe();
   if (!signedUser || signedUser.role === 'ADMIN') {
     return redirect('/', RedirectType.replace);
   }

--- a/app/(pages)/(private)/student-card/status/page.tsx
+++ b/app/(pages)/(private)/student-card/status/page.tsx
@@ -7,7 +7,7 @@ import Link from 'next/link';
 import { redirect, RedirectType } from 'next/navigation';
 
 export default async function Page() {
-  const signedUser = await identity.isLoggedIn();
+  const signedUser = await identity.getMe();
   if (!signedUser || signedUser.role === 'ADMIN') {
     return redirect('/', RedirectType.replace);
   }

--- a/app/(pages)/(private)/update-profile/action.ts
+++ b/app/(pages)/(private)/update-profile/action.ts
@@ -4,7 +4,7 @@ import { createUserRepository } from '@/repositories/userRepository';
 import { cryptography } from '@/services/cryptography';
 import { lambda } from '@/services/lambda';
 import { forgotPrivateKeyUseCase } from '@/useCases/forgotPrivateKeyUseCase';
-import { createUpdatePendingDataUseCase } from '@/useCases/updatePendingDataUseCase';
+import { updatePendingDataUseCase } from '@/useCases/updatePendingDataUseCase';
 import { revalidatePath } from 'next/cache';
 import { ZodIssue } from 'zod';
 
@@ -52,8 +52,6 @@ async function updateRejectedPendingDataAction(
   input: EditUserRegisterFormProps,
 ) {
   const userRepository = createUserRepository();
-  const { updatePendingDataUseCase } =
-    createUpdatePendingDataUseCase(userRepository);
 
   const { userId, pendingDataId, ...data } = input;
 
@@ -72,7 +70,7 @@ async function updateRejectedPendingDataAction(
     dataToUpdate.photoUrl = file_url;
   }
 
-  const response = await updatePendingDataUseCase({
+  const response = await updatePendingDataUseCase(userRepository, {
     id: pendingDataId!,
     dataToUpdate,
   });

--- a/app/(pages)/(private)/update-profile/page.tsx
+++ b/app/(pages)/(private)/update-profile/page.tsx
@@ -6,7 +6,7 @@ import { redirect, RedirectType } from 'next/navigation';
 import { EditUserRegisterForm } from './components/EditUserRegisterForm';
 
 export default async function Page() {
-  const signedUser = await identity.isLoggedIn();
+  const signedUser = await identity.getMe();
   const acceptedUserStatus: UserStatus[] = ['FORGOT_PK', 'REJECTED'];
 
   if (

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,7 +3,7 @@ import { Box, Text } from '@primer/react';
 import Link from 'next/link';
 
 export default async function Home() {
-  const signedUser = await identity.isLoggedIn();
+  const signedUser = await identity.getMe();
 
   return (
     <Box>

--- a/app/pageLayout.tsx
+++ b/app/pageLayout.tsx
@@ -10,7 +10,7 @@ type Props = {
 };
 
 export async function PageLayout({ children }: Props) {
-  const userSigned = await identity.isLoggedIn();
+  const userSigned = await identity.getMe();
 
   return (
     <Box

--- a/app/ui/Header.tsx
+++ b/app/ui/Header.tsx
@@ -15,7 +15,7 @@ async function signOutAction() {
 }
 
 export async function Header({ ...props }: BoxProps) {
-  const signedUser = await identity.isLoggedIn();
+  const signedUser = await identity.getMe();
 
   return (
     <Box

--- a/app/ui/Sidebar.tsx
+++ b/app/ui/Sidebar.tsx
@@ -4,7 +4,7 @@ import { Box, NavList } from '@primer/react';
 import { NavListItem } from '../components/NavListItem';
 
 export async function Sidebar() {
-  const userSignedIn = await identity.isLoggedIn();
+  const userSignedIn = await identity.getMe();
   const isUserAdmin = userSignedIn && userSignedIn.role === 'ADMIN';
   const userCanUpdateProfile =
     userSignedIn && ['FORGOT_PK', 'REJECTED'].includes(userSignedIn.status);

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,7 +1,6 @@
 import { constants } from '@/utils/constants';
 import { navItems } from '@/utils/navItems';
 import { jwtVerify } from 'jose';
-import { cookies } from 'next/headers';
 import { NextRequest, NextResponse } from 'next/server';
 
 export async function middleware(request: NextRequest) {
@@ -10,36 +9,19 @@ export async function middleware(request: NextRequest) {
   const accessToken = request.cookies.get(constants.access_token_key)?.value;
   const response = NextResponse.next();
 
-  const privatePages = navItems
-    .filter((item) => item.auth.isPrivate)
-    .map((item) => item.href as string);
-
-  if (!accessToken && privatePages.includes(pathname)) {
-    return NextResponse.redirect(new URL('/', request.url));
+  if (!accessToken && isPrivatePage(pathname)) {
+    return redirectToHomePage(request);
   }
 
   if (accessToken) {
+    if (isOnlyNotSignedInPage(pathname)) {
+      return redirectToHomePage(request);
+    }
+
     try {
-      const { payload } = await jwtVerify(
-        accessToken,
-        new TextEncoder().encode(constants.jwt_secret),
-      );
+      const secret = new TextEncoder().encode(constants.jwt_secret);
 
-      const { sub: userId } = payload;
-      if (userId) {
-        response.headers.set(constants.user_id_header_key, userId);
-      }
-
-      const onlyNotSignedInPages = navItems
-        .filter((item) => item.auth.onlyNotSignedIn)
-        .map((item) => item.href as string);
-
-      if (onlyNotSignedInPages.includes(pathname) && userId) {
-        if (process.env.NODE_ENV === 'development') {
-          cookies().delete(constants.access_token_key);
-        }
-        return NextResponse.redirect(new URL('/', request.url));
-      }
+      await jwtVerify(accessToken, secret);
     } catch {
       response.cookies.delete(constants.access_token_key);
     }
@@ -53,3 +35,23 @@ export const config = {
     '/((?!_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)',
   ],
 };
+
+function redirectToHomePage(request: NextRequest) {
+  return NextResponse.redirect(new URL('/', request.url));
+}
+
+function isOnlyNotSignedInPage(pathname: string) {
+  const onlyNotSignedInPages = navItems
+    .filter((item) => item.auth.onlyNotSignedIn)
+    .map((item) => item.href as string);
+
+  return onlyNotSignedInPages.includes(pathname);
+}
+
+function isPrivatePage(pathname: string) {
+  const privatePages = navItems
+    .filter((item) => item.auth.isPrivate)
+    .map((item) => item.href as string);
+
+  return privatePages.includes(pathname);
+}

--- a/utils/idendity.ts
+++ b/utils/idendity.ts
@@ -4,10 +4,10 @@ import { jwtVerify } from 'jose';
 import { cookies } from 'next/headers';
 
 export const identity = Object.freeze({
-  isLoggedIn,
+  getMe,
 });
 
-async function isLoggedIn() {
+async function getMe() {
   const userId = await getUserIdFromJwtCookies();
 
   if (!userId) return null;

--- a/utils/idendity.ts
+++ b/utils/idendity.ts
@@ -1,13 +1,14 @@
 import { createUserRepository } from '@/repositories/userRepository';
 import { constants } from '@/utils/constants';
-import { headers } from 'next/headers';
+import { jwtVerify } from 'jose';
+import { cookies } from 'next/headers';
 
 export const identity = Object.freeze({
   isLoggedIn,
 });
 
 async function isLoggedIn() {
-  const userId = headers().get(constants.user_id_header_key);
+  const userId = await getUserIdFromJwtCookies();
 
   if (!userId) return null;
 
@@ -17,4 +18,20 @@ async function isLoggedIn() {
   if (!user) return null;
 
   return user;
+}
+
+async function getUserIdFromJwtCookies() {
+  const accessToken = cookies().get(constants.access_token_key)?.value;
+  if (!accessToken) return null;
+
+  try {
+    const secret = new TextEncoder().encode(constants.jwt_secret);
+    const { payload } = await jwtVerify(accessToken, secret);
+    const userId = payload.sub;
+    if (!userId) return null;
+
+    return userId;
+  } catch {
+    return null;
+  }
 }


### PR DESCRIPTION
## Context
Prior to this PR, `middleware.ts` was handling authorization by:

- Verifying the JWT token from cookies.
- Extracting the userId from the verified token.
- Setting the userId in the next page headers using response.headers.set(...).
- On private pages (which require the user ID to confirm if the user is logged in), extracting the userId from headers and fetching the user by ID.

Now, the entire flow is simplified:

- `middleware.ts` is only responsible for verifying the JWT token (ensuring it was correctly generated by the backend).
- On private pages (which require the user ID for login verification), a utility function is used to extract the userId from cookies and fetch the user by ID.

This directly impacts the authorization process. As a result, I refactored the utility function responsible for retrieving the user by ID or returning null. I added an additional step before attempting to fetch the user by ID: now, it verifies the JWT token and extracts the userId first.
 
 ## Done
 - refactored `middleware.ts` by removing the logic of set `user id` in response headers
 - implemented `getUserIdFromJwtCookies` utility function to get `user id` from `jwt token`
 - added a `layout.tsx` in `/issued-cards`, to verify if user is logged and has a `ADMIN` role
 - renamed `idendity.isLoggedIn` to `identity.getMe` utility function