### PR TITLE
Adjusts `cd.yaml` to access `GITHUB TOKEN` correctly

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -7,7 +7,7 @@ on:
 env:
   DATABASE_URL: ${{ secrets.DATABASE_URL }}
   VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-  STD_IDENTIFICATION_PULL_REQUEST_NUMBER: ${{ github.event.number }}
+  STD_IDENTIFICATION_GITHUB_TOKEN: ${{ secrets.STD_IDENTIFICATION_GITHUB_TOKEN }}
 
 jobs:
   deploy:


### PR DESCRIPTION
## Context
I forgot to configure `cd.yaml` to access the `GITHUB TOKEN` correctly, defined on github `secrets`.