### PR TITLE
Provides student private key via `file`

### DIFF
--- a/app/(pages)/(private)/student-card/components/StudentCard.tsx
+++ b/app/(pages)/(private)/student-card/components/StudentCard.tsx
@@ -236,6 +236,7 @@ export function StudentCard({ ethAddress, userId }: StudentCardProps) {
                   label="Chave privada"
                   name="private_key"
                   type="file"
+                  accept=".txt"
                   onChange={(e) => {
                     const file = e.target.files?.[0];
                     if (!file) return;

--- a/app/(pages)/(private)/student-card/components/StudentCard.tsx
+++ b/app/(pages)/(private)/student-card/components/StudentCard.tsx
@@ -7,6 +7,7 @@ import { CheckCircleFillIcon, XCircleFillIcon } from '@primer/octicons-react';
 import {
   Box,
   Button,
+  Checkbox,
   Dialog,
   Label,
   Text,
@@ -144,6 +145,9 @@ export function StudentCard({ ethAddress, userId }: StudentCardProps) {
     const [privateKey, setPrivateKey] = useState('');
     const [isDialogOpen, setIsDialogOpen] = useState(false);
     const [invalidCredentialsError, setInvalidCredentialsError] = useState('');
+    const [privateKeyMode, setPrivateKeyMode] = useState<'write' | 'file'>(
+      'write',
+    );
 
     async function handleDecryptStudentCard(event: React.FormEvent) {
       event.preventDefault();
@@ -179,7 +183,7 @@ export function StudentCard({ ethAddress, userId }: StudentCardProps) {
           }}
         >
           <form>
-            <Dialog.Header id="header">Title</Dialog.Header>
+            <Dialog.Header id="header">Descriptografar carteira</Dialog.Header>
             <Box
               sx={{
                 padding: 3,
@@ -188,12 +192,62 @@ export function StudentCard({ ethAddress, userId }: StudentCardProps) {
                 gap: 2,
               }}
             >
-              <label htmlFor="private_key">Chave privada:</label>
-              <Textarea
-                id="private_key"
-                sx={{ padding: '10px', borderRadius: '4px' }}
-                onChange={(e) => setPrivateKey(e.target.value)}
-              />
+              <Box
+                sx={{
+                  display: 'flex',
+                  gap: 2,
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                }}
+              >
+                <label htmlFor="private-key-mode">
+                  Habilitar upload de arquivo para chave privada
+                </label>
+                <Checkbox
+                  sx={{
+                    borderRadius: '50%',
+                  }}
+                  id="private-key-mode"
+                  onChange={() => {
+                    setPrivateKeyMode(
+                      privateKeyMode === 'write' ? 'file' : 'write',
+                    );
+                  }}
+                />
+              </Box>
+
+              {privateKeyMode === 'write' && (
+                <>
+                  <label htmlFor="private_key">Chave privada:</label>
+                  <Textarea
+                    id="private_key"
+                    sx={{ padding: '10px', borderRadius: '4px' }}
+                    onChange={(e) => setPrivateKey(e.target.value)}
+                  />
+                </>
+              )}
+
+              {privateKeyMode === 'file' && (
+                <CustomInput
+                  sx={{
+                    padding: '10px',
+                    borderRadius: '4px',
+                  }}
+                  label="Chave privada"
+                  name="private_key"
+                  type="file"
+                  onChange={(e) => {
+                    const file = e.target.files?.[0];
+                    if (!file) return;
+
+                    const reader = new FileReader();
+                    reader.onload = (e) => {
+                      setPrivateKey(e.target?.result as string);
+                    };
+                    reader.readAsText(file);
+                  }}
+                />
+              )}
 
               <CustomInput
                 label="Senha"

--- a/app/(pages)/(private)/update-profile/components/EditUserRegisterForm.tsx
+++ b/app/(pages)/(private)/update-profile/components/EditUserRegisterForm.tsx
@@ -35,6 +35,7 @@ export function EditUserRegisterForm({
         data={{
           message: state.data.message,
           privateKey: state.data.privateKey,
+          userName: user.name,
         }}
         type="forgotPrivateKey"
       />

--- a/app/components/Instructions.tsx
+++ b/app/components/Instructions.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { CopyToClipBoard } from '@/app/components/CopyToClipboard';
+import { DownloadIcon } from '@primer/octicons-react';
 import { Button, Flash } from '@primer/react';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
@@ -9,13 +10,28 @@ type InstructionsProps = {
   data: {
     message: string;
     privateKey: string;
+    userName: string;
   };
   type: 'register' | 'forgotPrivateKey';
 };
 
 export function Instructions({ data, type }: InstructionsProps) {
   const [isCopied, setIsCopied] = useState(false);
+  const [isDownloaded, setIsDownloaded] = useState(false);
   const route = useRouter();
+
+  function downloadPrivateKey(privateKey: string, fileName: string) {
+    const blob = new Blob([privateKey]);
+
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = fileName.concat('.txt');
+    link.click();
+    URL.revokeObjectURL(url);
+  }
+
+  const fileName = 'chave-privada-'.concat(data.userName);
 
   return (
     <Flash
@@ -42,13 +58,28 @@ export function Instructions({ data, type }: InstructionsProps) {
         Copiar chave privada
       </CopyToClipBoard>
 
+      <Button
+        title="Baixar chave privada em arquivo .txt"
+        sx={{
+          width: 'fit-content',
+          marginX: 'auto',
+        }}
+        onClick={() => {
+          downloadPrivateKey(data.privateKey, fileName);
+          setIsDownloaded(true);
+        }}
+      >
+        <DownloadIcon />
+        Baixar chave privada
+      </Button>
+
       {type === 'register' ? (
         <Button
           onClick={() => {
             route.replace('/login');
             route.refresh();
           }}
-          disabled={!isCopied}
+          disabled={!isCopied && !isDownloaded}
           variant="primary"
           sx={{
             mt: 4,
@@ -64,7 +95,7 @@ export function Instructions({ data, type }: InstructionsProps) {
             route.replace('/student-card/status');
             route.refresh();
           }}
-          disabled={!isCopied}
+          disabled={!isCopied && !isDownloaded}
           variant="primary"
           sx={{
             mt: 4,

--- a/tests/useCases/registerUserUseCase.test.ts
+++ b/tests/useCases/registerUserUseCase.test.ts
@@ -84,6 +84,7 @@ describe('> Register User Use Case', () => {
       data: {
         message: 'Usuário cadastrado com sucesso. Aprovação pendente!',
         privateKey: expect.any(String),
+        userName: 'John Doe',
       },
     });
 

--- a/useCases/registerUserUseCase.ts
+++ b/useCases/registerUserUseCase.ts
@@ -95,6 +95,7 @@ export async function registerUserUseCase(
     errors: null,
     data: {
       message: 'Usuário cadastrado com sucesso. Aprovação pendente!',
+      userName: input.name,
       privateKey,
     },
   };


### PR DESCRIPTION
## Context
- Before this PR, when a user registered, they only had the option to copy the private key. Now they have the option to download it as a `.txt` file as well.
- When a user was trying to decrypt their student card, they only had the option to provide a private key by typing or pasting it into a `textarea`, now they have the option to upload a file

## Done
- Added `userName` in the return of `registerUserUseCase` function
- Implemented option to download private key in `Instructions` component
- Implemented functionality of decrypt user student card providing the private key as a file

## Preview
[Gravação de tela de 23-10-2024 23:35:12.webm](https://github.com/user-attachments/assets/80ef2b89-a906-42da-a760-13b79cce8ad0)
