### PR TITLE
Refacts user `forgot private key` flow

### DIFF
--- a/app/(pages)/(private)/(admin)/pending-cards/action.ts
+++ b/app/(pages)/(private)/(admin)/pending-cards/action.ts
@@ -33,7 +33,7 @@ export async function encryptUserPendingDataAction(
       number,
       photoUrl,
       registration,
-      rejection_reason,
+      rejectionReason,
     } = userPendingData;
 
     const firstPart = cryptography.encryptData({
@@ -56,7 +56,7 @@ export async function encryptUserPendingDataAction(
         number,
         photoUrl,
         registration,
-        rejection_reason,
+        rejectionReason,
       },
       publicKey: user.publicKey,
     });
@@ -115,6 +115,13 @@ export async function updateUserAction(id: string, input: UpdateUserInput) {
   return revalidatePath('/pending-cards');
 }
 
+export async function resetOldEthAddressAction(userId: string) {
+  const userRepository = createUserRepository();
+  await userRepository.updateOldEthAddress(userId, '');
+
+  return revalidatePath('/pending-cards');
+}
+
 export async function updateUserRejectionReasonAction(
   id: string,
   rejection_reason: string,
@@ -123,7 +130,7 @@ export async function updateUserRejectionReasonAction(
   await userRepository.updatePendingData({
     id,
     dataToUpdate: {
-      rejection_reason,
+      rejectionReason: rejection_reason,
     },
   });
 }

--- a/app/(pages)/(private)/student-card/action.ts
+++ b/app/(pages)/(private)/student-card/action.ts
@@ -37,12 +37,19 @@ export async function decryptUserDataAction({
   };
 }
 
-export async function updateUserStatusAction(payload: {
+export async function updateUserAction(payload: {
   userId: string;
   status: UserStatus;
+  oldEthAddress: string;
 }) {
   const userRepository = createUserRepository();
 
-  await userRepository.updateStatus(payload.userId, payload.status);
+  const updatePromises = [
+    userRepository.updateStatus(payload.userId, payload.status),
+    userRepository.updateOldEthAddress(payload.userId, payload.oldEthAddress),
+  ];
+
+  await Promise.all(updatePromises);
+
   return redirect('/student-card/status');
 }

--- a/app/(pages)/(private)/student-card/components/ForgotPrivateKeyForm.tsx
+++ b/app/(pages)/(private)/student-card/components/ForgotPrivateKeyForm.tsx
@@ -1,11 +1,10 @@
 'use client';
 
 import { LoadingButton } from '@/app/components/LoadingButton';
-import { useWeb3Context } from '@/app/contexts/Web3Context';
 import { Box, Button, Dialog, Label, Text } from '@primer/react';
 import { Divider } from '@primer/react/lib-esm/ActionList/Divider';
 import { useState } from 'react';
-import { updateUserStatusAction } from '../action';
+import { updateUserAction } from '../action';
 
 type ForgotPrivateKeyFormProps = {
   ethAddress: string;
@@ -19,14 +18,12 @@ export function ForgotPrivateKeyForm({
   const [isForgotPrivateKeyModalOpen, setIsForgotPrivateKeyModalOpen] =
     useState(false);
 
-  const { account, contract } = useWeb3Context();
-
   async function handleForgotPrivateKey() {
-    if (!contract || !account) return;
-
-    await contract.methods.invalidateCard(ethAddress).send({ from: account });
-
-    updateUserStatusAction({ status: 'FORGOT_PK', userId });
+    await updateUserAction({
+      userId,
+      status: 'FORGOT_PK',
+      oldEthAddress: ethAddress,
+    });
 
     setIsForgotPrivateKeyModalOpen(false);
   }

--- a/app/(pages)/(private)/student-card/page.tsx
+++ b/app/(pages)/(private)/student-card/page.tsx
@@ -1,3 +1,4 @@
+import { contractAddress } from '@/contract/contract-address';
 import { abi } from '@/contract/smart-contract-abi';
 import { constants } from '@/utils/constants';
 import { identity } from '@/utils/idendity';
@@ -28,11 +29,19 @@ export default async function Page() {
     );
   }
 
-  const web3 = new Web3(
-    `https://sepolia.infura.io/v3/${process.env.INFURA_API_KEY}`,
-  );
+  const studentWeb3Provider =
+    process.env.NODE_ENV === 'production'
+      ? `https://sepolia.infura.io/v3/${process.env.INFURA_API_KEY}`
+      : constants.ganache_url;
 
-  const contract = new web3.eth.Contract(abi, constants.smart_contract_address);
+  const web3 = new Web3(studentWeb3Provider);
+
+  const smartContractAddress =
+    process.env.NODE_ENV === 'production'
+      ? constants.smart_contract_address
+      : contractAddress;
+
+  const contract = new web3.eth.Contract(abi, smartContractAddress);
 
   const studentCard = await contract.methods
     .getCard(signedUser.ethAddress)

--- a/app/(pages)/(private)/student-card/status/page.tsx
+++ b/app/(pages)/(private)/student-card/status/page.tsx
@@ -19,7 +19,7 @@ export default async function Page() {
       signedUser.id,
     );
 
-    rejectionReason = pendingUserData?.rejection_reason ?? '';
+    rejectionReason = pendingUserData?.rejectionReason ?? '';
     revalidatePath('/student-card/status');
   }
 

--- a/app/(pages)/(private)/update-profile/components/EditUserRegisterForm.tsx
+++ b/app/(pages)/(private)/update-profile/components/EditUserRegisterForm.tsx
@@ -81,7 +81,7 @@ export function EditUserRegisterForm({
               size="large"
               variant={user.status === 'FORGOT_PK' ? 'attention' : 'danger'}
             >
-              {user.status}
+              {user.status === 'FORGOT_PK' && 'Esqueceu a chave privada'}
             </Label>
           </Box>
 

--- a/prisma/migrations/20241029224831_adds_old_eth_address_column_in_users_tale/migration.sql
+++ b/prisma/migrations/20241029224831_adds_old_eth_address_column_in_users_tale/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN     "old_eth_address" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -30,6 +30,7 @@ model User {
   password        String
   publicKey       String     @unique @map("public_key")
   ethAddress      String     @unique @map("eth_address")
+  oldEthAddress   String?    @map("old_eth_address")
   status          UserStatus @default(PENDING)
   role            UserRoles  @default(USER)
   transactionHash String?    @map("transaction_hash")
@@ -41,20 +42,20 @@ model User {
 }
 
 model UserPendingData {
-  id               String   @id @default(uuid())
-  userId           String   @unique @map("user_id")
-  name             String
-  email            String
-  cpf              String
-  cep              String
-  address          String
-  number           String
-  registration     Int      @default(autoincrement())
-  complement       String?
-  course           String
-  photoUrl         String   @map("photo_url")
-  rejection_reason String?  @map("rejection_reason")
-  createdAt        DateTime @default(now()) @map("created_at")
+  id              String   @id @default(uuid())
+  userId          String   @unique @map("user_id")
+  name            String
+  email           String
+  cpf             String
+  cep             String
+  address         String
+  number          String
+  registration    Int      @default(autoincrement())
+  complement      String?
+  course          String
+  photoUrl        String   @map("photo_url")
+  rejectionReason String?  @map("rejection_reason")
+  createdAt       DateTime @default(now()) @map("created_at")
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade, onUpdate: Cascade)
 

--- a/repositories/userRepository.ts
+++ b/repositories/userRepository.ts
@@ -37,7 +37,7 @@ export type UpdatePendingDataInput = {
     complement?: string;
     course?: string;
     photoUrl?: string;
-    rejection_reason?: string;
+    rejectionReason?: string;
   };
 };
 
@@ -46,6 +46,10 @@ type UpdatePublicKeysInput = {
   publicKey: string;
   ethAddress: string;
 };
+
+export type PendingUsersOutput = Awaited<
+  ReturnType<UserRepository['findPendingUsers']>
+>;
 
 export type UserRepository = ReturnType<typeof createUserRepository>;
 
@@ -58,6 +62,7 @@ export function createUserRepository() {
     findPendingUsers,
     deletePendingData,
     updateStatus,
+    updateOldEthAddress,
     updateTransactionHash,
     updatePublicKeys,
     updatePendingData,
@@ -81,6 +86,7 @@ export function createUserRepository() {
         email: true,
         publicKey: true,
         ethAddress: true,
+        oldEthAddress: true,
         status: true,
         createdAt: true,
         role: true,
@@ -149,6 +155,17 @@ export function createUserRepository() {
     });
   }
 
+  async function updateOldEthAddress(userId: string, ethAddress: string) {
+    return await prismaClient.user.update({
+      where: {
+        id: userId,
+      },
+      data: {
+        oldEthAddress: ethAddress,
+      },
+    });
+  }
+
   async function updatePublicKeys({
     userId,
     ethAddress,
@@ -198,6 +215,13 @@ export function createUserRepository() {
           status: 'PENDING',
           AND: {
             role: 'USER',
+          },
+        },
+      },
+      include: {
+        user: {
+          select: {
+            oldEthAddress: true,
           },
         },
       },

--- a/tests/repositories/userRepository.test.ts
+++ b/tests/repositories/userRepository.test.ts
@@ -152,7 +152,7 @@ describe('> User Repository', () => {
         complement: 'Casa',
         course: 'Ciência da Computação',
         photoUrl: 'http://test.com/photo.jpg',
-        rejection_reason: null,
+        rejectionReason: null,
         createdAt: expect.any(Date),
       },
     ]);
@@ -259,7 +259,7 @@ describe('> User Repository', () => {
       number: '123',
       course: 'Ciência da Computação',
       photoUrl: 'http://test.com/photo.jpg',
-      rejection_reason: null,
+      rejectionReason: null,
       createdAt: expect.any(Date),
     });
   });

--- a/tests/repositories/userRepository.test.ts
+++ b/tests/repositories/userRepository.test.ts
@@ -154,6 +154,9 @@ describe('> User Repository', () => {
         photoUrl: 'http://test.com/photo.jpg',
         rejectionReason: null,
         createdAt: expect.any(Date),
+        user: {
+          oldEthAddress: null,
+        },
       },
     ]);
   });

--- a/tests/useCases/forgotPrivateKeyUseCase.test.ts
+++ b/tests/useCases/forgotPrivateKeyUseCase.test.ts
@@ -355,7 +355,7 @@ describe('> Forgot Private Key Use Case', () => {
       complement: pendingDataInput.complement,
       course: pendingDataInput.course,
       photoUrl: '',
-      rejection_reason: null,
+      rejectionReason: null,
       createdAt: expect.any(Date),
     });
 


### PR DESCRIPTION
## Context
- In the previous PR (https://github.com/SouzaGabriel26/student-identification/pull/89) I configured the application for a normal user to use `infura` as the `Web3` provider. But I forgot to configure it for the `development` environment.
- This PR adjusts and refactors the user-side flow `forgot private key` that was using the old `web3Context` (now it is used only by admin users, who must have metamask installed).

## Done
- Added `oldEthAddress` in users table.
- Adjusted `web3 connection` and `provider` to normal users in development environment.
- Adjusted `forgot private key` flow by just updating user infos instead of invalidate card too.
- Reset `oldEthAddress` value (if exists) when `admin` approves users `forgot private key` request.

## Preview
[Gravação de tela de 29-10-2024 21:23:31.webm](https://github.com/user-attachments/assets/820c0ecd-1c4e-436c-a8f6-a111d4b3f275)
