### PR TITLE
Handle `admin` users first interaction with application (with no metamask installed)

### DIFF
--- a/app/(pages)/(private)/(admin)/layout.tsx
+++ b/app/(pages)/(private)/(admin)/layout.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { useWeb3Context } from '@/app/contexts/Web3Context';
+import { Box, Text } from '@primer/react';
+import { Banner } from '@primer/react/drafts';
+import Link from 'next/link';
+import { ReactNode } from 'react';
+
+type Props = {
+  children: ReactNode;
+};
+
+export default function Layout({ children }: Props) {
+  const { account, provider } = useWeb3Context();
+  const userDoesNotHaveMetamask = !provider && !account;
+  const userDidNotAcceptedAppInMetamask = provider === 'INJECTED' && !account;
+
+  return (
+    <>
+      {userDoesNotHaveMetamask && <InstallMetaMaskAlert />}
+      {userDidNotAcceptedAppInMetamask && <AcceptAppAlert />}
+      {children}
+    </>
+  );
+}
+
+function AcceptAppAlert() {
+  return (
+    <Box sx={{ py: 2 }}>
+      <Banner variant="warning">
+        <Text>Usuário ADMIN deve aceitar a aplicação no MetaMask</Text>
+      </Banner>
+    </Box>
+  );
+}
+
+function InstallMetaMaskAlert() {
+  return (
+    <Box sx={{ py: 2 }}>
+      <Banner variant="warning">
+        <Text>
+          Usuário ADMIN deve possuir a extensão{' '}
+          <Link
+            style={{ color: '#539bf5' }}
+            href="https://metamask.io/download/"
+            target="_blank"
+          >
+            MetaMask
+          </Link>{' '}
+          instalada no navegador
+        </Text>
+      </Banner>
+    </Box>
+  );
+}

--- a/app/(pages)/(private)/update-profile/components/EditUserRegisterForm.tsx
+++ b/app/(pages)/(private)/update-profile/components/EditUserRegisterForm.tsx
@@ -82,6 +82,7 @@ export function EditUserRegisterForm({
               variant={user.status === 'FORGOT_PK' ? 'attention' : 'danger'}
             >
               {user.status === 'FORGOT_PK' && 'Esqueceu a chave privada'}
+              {user.status === 'REJECTED' && 'Solicitação rejeitada'}
             </Label>
           </Box>
 

--- a/app/(pages)/login/action.ts
+++ b/app/(pages)/login/action.ts
@@ -23,10 +23,11 @@ export async function tryToLoginAction(_state: unknown, formData: FormData) {
 
   if (resultFromTryToLogin.data) {
     const { token } = resultFromTryToLogin.data;
-    const sevenDaysInMilliseconds = 60 * 60 * 24 * 7 * 1000;
     cookies().set(constants.access_token_key, token, {
-      expires: new Date(Date.now() + sevenDaysInMilliseconds),
       httpOnly: true,
+      maxAge: 7 * 24 * 60 * 60, // 7 days
+      path: '/',
+      sameSite: 'strict',
     });
 
     redirect('/');

--- a/app/pageLayout.tsx
+++ b/app/pageLayout.tsx
@@ -12,6 +12,44 @@ type Props = {
 export async function PageLayout({ children }: Props) {
   const userSigned = await identity.getMe();
 
+  if (userSigned && userSigned.role === 'ADMIN') {
+    return (
+      <Web3Provider>
+        <Box
+          sx={{
+            bg: 'canvas.default',
+            minHeight: '100vh',
+            display: 'flex',
+            flexDirection: 'column',
+          }}
+        >
+          <Header />
+
+          <Box
+            sx={{
+              flex: 1,
+              display: 'flex',
+            }}
+          >
+            <Sidebar />
+
+            <Box
+              sx={{
+                px: 4,
+                py: 2,
+                width: '100%',
+                height: '90vh',
+                overflowY: 'auto',
+              }}
+            >
+              {children}
+            </Box>
+          </Box>
+        </Box>
+      </Web3Provider>
+    );
+  }
+
   return (
     <Box
       sx={{
@@ -40,11 +78,7 @@ export async function PageLayout({ children }: Props) {
             overflowY: 'auto',
           }}
         >
-          {userSigned && userSigned.role === 'ADMIN' ? (
-            <Web3Provider>{children}</Web3Provider>
-          ) : (
-            children
-          )}
+          {children}
         </Box>
       </Box>
     </Box>

--- a/infra/compose.yaml
+++ b/infra/compose.yaml
@@ -10,3 +10,4 @@ services:
       - POSTGRES_HOST=${DEFAULT_POSTGRES_HOST}
       - POSTGRES_PORT=${DEFAULT_POSTGRES_PORT}
       - POSTGRES_DB=${DEFAULT_POSTGRES_DB}
+    restart: 'always'


### PR DESCRIPTION
## Context
- This PR aims to improve the user experience for `ADMIN` users. It brings validations and information about how to proceed if the user does not have metamask installed or has not accepted the application to interact with metamask.

## Done
- Added `restart: always` docker compose policy.
- Adjusted cookies config on `login` action.
- Added validation to when user has status equals to `rejected`.
- Added validations to check if `ADMIN` users have metamask installed and can to interact.

## Preview
> User does not have metamask installed

[Gravação de tela de 30-10-2024 22:31:48.webm](https://github.com/user-attachments/assets/a2f8eac8-cf84-4d95-98de-c743e114fc6d)

> User did not accepted metamask to interact with application yet

[Gravação de tela de 30-10-2024 22:33:36.webm](https://github.com/user-attachments/assets/728d71bf-435f-490f-be95-7aa1bb8495b6)
